### PR TITLE
JWT token 추가 및 API instance 로직 수정

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,9 @@ const nextConfig: NextConfig = {
 
     return config;
   },
+  images: {
+    domains: ['picsum.photos'],
+  },
 };
 
 export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@tanstack/react-query": "^5.66.0",
     "axios": "^1.7.9",
     "classnames": "^2.5.1",
+    "cookies-next": "^5.1.0",
     "next": "15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
+      cookies-next:
+        specifier: ^5.1.0
+        version: 5.1.0(next@15.1.0(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.83.4))(react@19.0.0)
       next:
         specifier: 15.1.0
         version: 15.1.0(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.83.4)
@@ -1879,6 +1882,16 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
+
+  cookies-next@5.1.0:
+    resolution: {integrity: sha512-9Ekne+q8hfziJtnT9c1yDUBqT0eDMGgPrfPl4bpR3xwQHLTd/8gbSf6+IEkP/pjGsDZt1TGbC6emYmFYRbIXwQ==}
+    peerDependencies:
+      next: '>=15.0.0'
+      react: '>= 16.8.0'
 
   copy-anything@2.0.6:
     resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
@@ -6338,6 +6351,14 @@ snapshots:
       split2: 4.2.0
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.0.2: {}
+
+  cookies-next@5.1.0(next@15.1.0(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.83.4))(react@19.0.0):
+    dependencies:
+      cookie: 1.0.2
+      next: 15.1.0(@babel/core@7.26.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.83.4)
+      react: 19.0.0
 
   copy-anything@2.0.6:
     dependencies:

--- a/src/app/_components/concert/concert-card/concert-card.tsx
+++ b/src/app/_components/concert/concert-card/concert-card.tsx
@@ -30,7 +30,7 @@ const ConcertCard = ({ concertItem }: ConcertCardProps) => {
 
   return (
     <>
-      <Link href={'concert/:id'}>
+      <Link href={`concert/${concertId}`}>
         <div className={styles.container}>
           <div className={styles.tag}>
             <Badge type="type-a">선예매까지 D-12</Badge>

--- a/src/app/_components/concert/concert-card/concert-card.tsx
+++ b/src/app/_components/concert/concert-card/concert-card.tsx
@@ -1,22 +1,33 @@
+import Image from 'next/image';
 import Link from 'next/link';
 
 import { LocationOnIcon } from '@/assets/icons';
 import Badge from '@/shared/components/badge/badge';
+import { Concert } from '@/shared/types';
 
 import styles from './concert-card.module.scss';
 
-interface ConcertItem {
-  title: string;
-  date: string;
-  place: string;
-  img: string;
-}
-
 interface ConcertCardProps {
-  concertItem: ConcertItem;
+  concertItem: Concert;
 }
 
 const ConcertCard = ({ concertItem }: ConcertCardProps) => {
+  const {
+    concertId,
+    concertName,
+    concertHallName,
+    concertType,
+    ticketReservationSite,
+    ticketPreOpenDate,
+    preOpenBankTransfer,
+    ticketGeneralOpenDate,
+    generalOpenBankTransfer,
+    startDate,
+    endDate,
+    concertThumbnailUrl,
+    seatingChartUrl,
+  } = concertItem;
+
   return (
     <>
       <Link href={'concert/:id'}>
@@ -29,10 +40,9 @@ const ConcertCard = ({ concertItem }: ConcertCardProps) => {
           {/* 콘서트 정보 */}
           <div className={styles.card_container}>
             <div className={styles.concert_img}>
-              {/* 추후 next의 Image 로 변경 예정 */}
-              <img
-                src={concertItem.img}
-                alt={concertItem.title}
+              <Image
+                src={concertThumbnailUrl}
+                alt={concertHallName}
                 width={104}
                 height={139}
               />
@@ -40,12 +50,14 @@ const ConcertCard = ({ concertItem }: ConcertCardProps) => {
 
             <div className={styles.concert_info}>
               <div className={styles.description}>
-                <span className={styles.date}>{concertItem.date}</span>
-                <span className={styles.title}>{concertItem.title}</span>
+                <span
+                  className={styles.date}
+                >{`${startDate} ~ ${endDate}`}</span>
+                <span className={styles.title}>{concertName}</span>
               </div>
               <div className={styles.place}>
                 <LocationOnIcon width={16} height={16} />
-                <span className={styles.location}>{concertItem.place}</span>
+                <span className={styles.location}>{concertHallName}</span>
               </div>
             </div>
           </div>

--- a/src/app/_components/concert/concert-list/concert-list.tsx
+++ b/src/app/_components/concert/concert-list/concert-list.tsx
@@ -3,61 +3,11 @@
 import React from 'react';
 
 import ConcertCard from '@/app/_components/concert/concert-card/concert-card';
+import { useGetConcertList } from '@/app/_shared/services/query';
 import { FilterListIcon } from '@/assets/icons';
 
 import ConcertDropdown from '../concert-dropdown';
 import styles from './concert-list.module.scss';
-
-const concert = [
-  {
-    title: '터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ’',
-    date: '2025.01.25 ~ 2025.02.01 ',
-    place: '블루스퀘어 마스터카드홀',
-    img: 'https://placehold.co/400x600',
-  },
-  {
-    title: '터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ’',
-    date: '2025.01.25 ~ 2025.02.01 ',
-    place: '블루스퀘어 마스터카드홀',
-    img: 'https://placehold.co/400x600',
-  },
-  {
-    title: '터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ’',
-    date: '2025.01.25 ~ 2025.02.01 ',
-    place: '블루스퀘어 마스터카드홀',
-    img: 'https://placehold.co/400x600',
-  },
-  {
-    title: '터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ’',
-    date: '2025.01.25 ~ 2025.02.01 ',
-    place: '블루스퀘어 마스터카드홀',
-    img: 'https://placehold.co/400x600',
-  },
-  {
-    title: '터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ’',
-    date: '2025.01.25 ~ 2025.02.01 ',
-    place: '블루스퀘어 마스터카드홀',
-    img: 'https://placehold.co/400x600',
-  },
-  {
-    title: '터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ’',
-    date: '2025.01.25 ~ 2025.02.01 ',
-    place: '블루스퀘어 마스터카드홀',
-    img: 'https://placehold.co/400x600',
-  },
-  {
-    title: '터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ’',
-    date: '2025.01.25 ~ 2025.02.01 ',
-    place: '블루스퀘어 마스터카드홀',
-    img: 'https://placehold.co/400x600',
-  },
-  {
-    title: '터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ’',
-    date: '2025.01.25 ~ 2025.02.01 ',
-    place: '블루스퀘어 마스터카드홀',
-    img: 'https://placehold.co/400x600',
-  },
-];
 
 const dropdownList = [
   {
@@ -71,6 +21,10 @@ const dropdownList = [
 ];
 
 const ConcertList = () => {
+  const { data } = useGetConcertList();
+
+  const concertList = data?.content;
+
   return (
     <>
       <div className={styles.container}>
@@ -84,8 +38,8 @@ const ConcertList = () => {
               <FilterListIcon width={20} height={20} />
             </div>
           </div>
-          {concert.map((concertItem) => (
-            <ConcertCard concertItem={concertItem} key={concertItem.title} />
+          {concertList?.map((concertItem, index) => (
+            <ConcertCard concertItem={concertItem} key={index} />
           ))}
         </div>
       </div>

--- a/src/app/_shared/services/api.ts
+++ b/src/app/_shared/services/api.ts
@@ -1,0 +1,25 @@
+import {
+  GetConcertListRequest,
+  GetConcertListResponse,
+} from '@/app/_shared/services/type';
+import instance from '@/shared/services/instance';
+import { createQueryParams } from '@/shared/utils/services/query-string';
+
+const BASE_URL = '/concert';
+
+/**
+ * @description 공연 목록 조회
+ */
+const getConcertList = async (request?: GetConcertListRequest) => {
+  const query = request
+    ? `?${createQueryParams(request as Record<string, unknown>)}`
+    : '';
+
+  const data = await instance<GetConcertListResponse>(`${BASE_URL}${query}`, {
+    method: 'GET',
+  });
+
+  return data;
+};
+
+export { getConcertList };

--- a/src/app/_shared/services/query-key.ts
+++ b/src/app/_shared/services/query-key.ts
@@ -1,0 +1,10 @@
+import { GetConcertListRequest } from '@/app/_shared/services/type';
+
+const queryKey = {
+  getConcertList: (request?: GetConcertListRequest) => [
+    'getConcertList',
+    request,
+  ],
+};
+
+export default queryKey;

--- a/src/app/_shared/services/query.ts
+++ b/src/app/_shared/services/query.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { getConcertList } from '@/app/_shared/services/api';
+import queryKey from '@/app/_shared/services/query-key';
+import { GetConcertListRequest } from '@/app/_shared/services/type';
+
+const useGetConcertList = (request?: GetConcertListRequest) => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: queryKey.getConcertList(request),
+    queryFn: () => getConcertList(request),
+  });
+
+  return { data, isLoading, isError };
+};
+
+export { useGetConcertList };

--- a/src/app/_shared/services/type.ts
+++ b/src/app/_shared/services/type.ts
@@ -1,0 +1,21 @@
+import {
+  Concert,
+  ConcertType,
+  Pagination,
+  TicketReservationSite,
+} from '@/shared/types';
+
+interface GetConcertListRequest {
+  concertName?: string; // 공연 제목 검색어 [선택]
+  concertHallName?: string; // 공연장 이름 검색어 [선택]
+  concertType?: ConcertType; // 공연 카테고리 [선택]
+  ticketReservationSite?: TicketReservationSite; // 예매처 사이트 [선택]
+  pageNumber?: number; // 요청 페이지 번호 [선택]
+  pageSize?: number; // 한 페이지 당 항목 수 [선택]
+  sortField?: string; // 정렬할 필드 [선택]
+  sortDirection?: string; // 정렬 방향 [선택]
+}
+
+type GetConcertListResponse = Pagination<Concert>;
+
+export type { GetConcertListRequest, GetConcertListResponse };

--- a/src/shared/services/instance.ts
+++ b/src/shared/services/instance.ts
@@ -1,15 +1,65 @@
+import { getCookie } from 'cookies-next';
+
+import { getAccessTokenFromServer } from '@/shared/utils/auth';
 import httpClient from '@/shared/utils/services/http-client';
 
 const instance = httpClient({
   baseURL: process.env.NEXT_PUBLIC_API_URL,
 
   interceptors: {
-    async response<T = unknown>(response: Response): Promise<T> {
-      const apiResponse = await response;
+    async request(
+      input: NonNullable<Parameters<typeof fetch>[0]>,
+      init: NonNullable<Parameters<typeof fetch>[1]>,
+    ): Promise<NonNullable<Parameters<typeof fetch>[1]>> {
+      let accessToken;
 
-      if (!apiResponse.ok) {
-        // unauthorized 401
-        if (apiResponse.status === 401) {
+      if (process.env.NODE_ENV === 'development') {
+        accessToken = process.env.NEXT_PUBLIC_ACCESS_TOKEN;
+      } else if (process.env.NODE_ENV === 'production') {
+        accessToken = getCookie('accessToken');
+      }
+
+      if (accessToken) {
+        init.headers = {
+          'Content-Type': 'application/json;charset=UTF-8',
+          ...init.headers,
+          Authorization: `Bearer ${accessToken}`,
+        };
+      }
+
+      return init;
+    },
+
+    async response<T = unknown>(
+      response: Response,
+      input: NonNullable<Parameters<typeof fetch>[0]>,
+      init: NonNullable<Parameters<typeof fetch>[1]>,
+    ): Promise<T> {
+      if (!response.ok) {
+        if (response.status === 401) {
+          const newAccessToken = await getAccessTokenFromServer();
+
+          if (newAccessToken) {
+            const retryHeaders = {
+              ...init.headers,
+              Authorization: `Bearer ${newAccessToken}`,
+            };
+
+            const retryResponse = await fetch(input, {
+              ...init,
+              headers: retryHeaders,
+            });
+
+            if (retryResponse.ok) {
+              return retryResponse.json() as Promise<T>;
+            } else {
+              // 재시도 실패
+              const retryErrorText = await retryResponse.text();
+              throw new Error(`Retry failed: ${retryErrorText}`);
+            }
+          }
+
+          // 재발급 실패 시 로그인으로
           if (
             window.confirm(
               '로그인이 필요한 페이지입니다. 로그인 창으로 이동하시겠습니까?',
@@ -20,11 +70,11 @@ const instance = httpClient({
           }
         }
 
-        const errorText = await apiResponse.text();
-        throw new Error(`HTTP error ${apiResponse.status}: ${errorText}`);
+        const errorText = await response.text();
+        throw new Error(`HTTP error ${response.status}: ${errorText}`);
       }
 
-      return apiResponse.json() as Promise<T>;
+      return response.json() as Promise<T>;
     },
   },
 });

--- a/src/shared/services/instance.ts
+++ b/src/shared/services/instance.ts
@@ -11,13 +11,10 @@ const instance = httpClient({
       input: NonNullable<Parameters<typeof fetch>[0]>,
       init: NonNullable<Parameters<typeof fetch>[1]>,
     ): Promise<NonNullable<Parameters<typeof fetch>[1]>> {
-      let accessToken;
-
-      if (process.env.NODE_ENV === 'development') {
-        accessToken = process.env.NEXT_PUBLIC_ACCESS_TOKEN;
-      } else if (process.env.NODE_ENV === 'production') {
-        accessToken = getCookie('accessToken');
-      }
+      const accessToken =
+        process.env.NODE_ENV === 'development'
+          ? process.env.NEXT_PUBLIC_ACCESS_TOKEN
+          : getCookie('accessToken');
 
       if (accessToken) {
         init.headers = {

--- a/src/shared/services/instance.ts
+++ b/src/shared/services/instance.ts
@@ -36,13 +36,18 @@ const instance = httpClient({
       init: NonNullable<Parameters<typeof fetch>[1]>,
     ): Promise<T> {
       if (!response.ok) {
+        console.log(response);
         if (response.status === 401) {
           const newAccessToken = await getAccessTokenFromServer();
 
+          console.log(response, newAccessToken);
+
           if (newAccessToken) {
+            const accessToken = await getCookie('accessToken');
+
             const retryHeaders = {
               ...init.headers,
-              Authorization: `Bearer ${newAccessToken}`,
+              Authorization: `Bearer ${accessToken}`,
             };
 
             const retryResponse = await fetch(input, {
@@ -57,16 +62,16 @@ const instance = httpClient({
               const retryErrorText = await retryResponse.text();
               throw new Error(`Retry failed: ${retryErrorText}`);
             }
-          }
-
-          // 재발급 실패 시 로그인으로
-          if (
-            window.confirm(
-              '로그인이 필요한 페이지입니다. 로그인 창으로 이동하시겠습니까?',
-            )
-          ) {
-            window.location.href = '/auth/sign-in';
-            return Promise.reject('Redirecting to login');
+          } else {
+            // 재발급 실패 시 로그인으로
+            if (
+              window.confirm(
+                '로그인이 필요한 페이지입니다. 로그인 창으로 이동하시겠습니까?',
+              )
+            ) {
+              window.location.href = '/auth/sign-in';
+              return Promise.reject('Redirecting to login');
+            }
           }
         }
 

--- a/src/shared/services/instance.ts
+++ b/src/shared/services/instance.ts
@@ -36,11 +36,8 @@ const instance = httpClient({
       init: NonNullable<Parameters<typeof fetch>[1]>,
     ): Promise<T> {
       if (!response.ok) {
-        console.log(response);
         if (response.status === 401) {
           const newAccessToken = await refreshAccessToken();
-
-          console.log(response, newAccessToken);
 
           if (newAccessToken) {
             const accessToken = await getCookie('accessToken');

--- a/src/shared/services/instance.ts
+++ b/src/shared/services/instance.ts
@@ -1,6 +1,6 @@
 import { getCookie } from 'cookies-next';
 
-import { getAccessTokenFromServer } from '@/shared/utils/auth';
+import { refreshAccessToken } from '@/shared/utils/auth';
 import httpClient from '@/shared/utils/services/http-client';
 
 const instance = httpClient({
@@ -38,7 +38,7 @@ const instance = httpClient({
       if (!response.ok) {
         console.log(response);
         if (response.status === 401) {
-          const newAccessToken = await getAccessTokenFromServer();
+          const newAccessToken = await refreshAccessToken();
 
           console.log(response, newAccessToken);
 

--- a/src/shared/types/api.ts
+++ b/src/shared/types/api.ts
@@ -1,0 +1,30 @@
+interface Pagination<T> {
+  totalElements: number;
+  totalPages: number;
+  size: number;
+  content: T[];
+  number: number;
+  sort: {
+    empty: boolean;
+    sorted: boolean;
+    unsorted: boolean;
+  };
+  numberOfElements: number;
+  pageable: {
+    offset: number;
+    sort: {
+      empty: boolean;
+      sorted: boolean;
+      unsorted: boolean;
+    };
+    paged: boolean;
+    pageNumber: number;
+    pageSize: number;
+    unpaged: boolean;
+  };
+  first: boolean;
+  last: boolean;
+  empty: boolean;
+}
+
+export type { Pagination };

--- a/src/shared/types/concert.ts
+++ b/src/shared/types/concert.ts
@@ -1,0 +1,34 @@
+type ConcertType =
+  | 'CONCERT'
+  | 'MUSICAL'
+  | 'SPORTS'
+  | 'CLASSIC'
+  | 'EXHIBITIONS'
+  | 'OPERA'
+  | 'ETC';
+
+type TicketReservationSite =
+  | 'INTERPARK_TICKET'
+  | 'YES24_TICKET'
+  | 'TICKEK_LINK'
+  | 'MELON_TICKET'
+  | 'COUPANG_PLAY'
+  | 'ETC';
+
+interface Concert {
+  concertId: string; // 공연 ID
+  concertName: string; // 공연 제목
+  concertHallName: string; // 공연장 이름
+  concertType: string; // 공연 카테고리
+  ticketReservationSite: string; // 예매처 사이트
+  ticketPreOpenDate: string; // 선예매 시작일
+  preOpenBankTransfer: boolean; // 선예매 계좌이체 가능 여부
+  ticketGeneralOpenDate: string; // 일반 예매 시작일
+  generalOpenBankTransfer: boolean; // 일반 예매 계좌이체 가능 여부
+  startDate: string; // 공연 시작일
+  endDate: string; // 공연 종료일
+  concertThumbnailUrl: string; // 공연 썸네일 URL
+  seatingChartUrl: string; // 좌석 배치도 URL
+}
+
+export type { ConcertType, TicketReservationSite, Concert };

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -1,0 +1,2 @@
+export * from './concert';
+export * from './api';

--- a/src/shared/utils/auth.ts
+++ b/src/shared/utils/auth.ts
@@ -1,0 +1,16 @@
+import { getCookie } from 'cookies-next';
+
+export const getAccessTokenFromServer = async () => {
+  const refreshToken = getCookie('refreshToken');
+
+  if (!refreshToken) return false;
+
+  const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/reissue`, {
+    method: 'POST',
+    credentials: 'include',
+  });
+
+  if (!res.ok || res.status !== 200) return false;
+
+  return getCookie('accessToken');
+};

--- a/src/shared/utils/auth.ts
+++ b/src/shared/utils/auth.ts
@@ -1,16 +1,20 @@
 import { getCookie } from 'cookies-next';
 
 export const getAccessTokenFromServer = async () => {
-  const refreshToken = getCookie('refreshToken');
+  const refreshToken = await getCookie('refreshToken');
 
   if (!refreshToken) return false;
+
+  console.log('getRefresh', refreshToken);
 
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/reissue`, {
     method: 'POST',
     credentials: 'include',
   });
 
+  console.log('reissue', res);
+
   if (!res.ok || res.status !== 200) return false;
 
-  return getCookie('accessToken');
+  return res.ok;
 };

--- a/src/shared/utils/auth.ts
+++ b/src/shared/utils/auth.ts
@@ -1,12 +1,4 @@
-import { getCookie } from 'cookies-next';
-
-export const getAccessTokenFromServer = async () => {
-  const refreshToken = await getCookie('refreshToken');
-
-  if (!refreshToken) return false;
-
-  console.log('getRefresh', refreshToken);
-
+export const refreshAccessToken = async () => {
   const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/auth/reissue`, {
     method: 'POST',
     credentials: 'include',

--- a/src/shared/utils/auth.ts
+++ b/src/shared/utils/auth.ts
@@ -4,8 +4,6 @@ export const refreshAccessToken = async () => {
     credentials: 'include',
   });
 
-  console.log('reissue', res);
-
   if (!res.ok || res.status !== 200) return false;
 
   return res.ok;

--- a/src/shared/utils/services/http-client.ts
+++ b/src/shared/utils/services/http-client.ts
@@ -10,7 +10,11 @@ export interface HTTPClientOption<T = Response>
       input: NonNullable<FetchParameters[0]>,
       init: NonNullable<FetchParameters[1]>,
     ): PromiseAble<FetchParameters[1]>;
-    response?(response: Response): PromiseAble<T>;
+    response?(
+      response: Response,
+      input: NonNullable<FetchParameters[0]>,
+      init: NonNullable<FetchParameters[1]>,
+    ): PromiseAble<T>;
   };
 }
 
@@ -42,10 +46,12 @@ export default function httpClient<T = Response>({
     const interceptorAppliedOption = interceptors.request
       ? await interceptors.request(url, option)
       : option;
-    const response = await fetch(url, interceptorAppliedOption);
+
+    const finalOption = interceptorAppliedOption ?? option;
+    const response = await fetch(url, finalOption);
 
     if (interceptors.response) {
-      return (await interceptors.response(response)) as R;
+      return (await interceptors.response(response, url, finalOption)) as R;
     }
 
     return response as R;

--- a/src/shared/utils/services/query-string.ts
+++ b/src/shared/utils/services/query-string.ts
@@ -1,0 +1,21 @@
+export const createQueryParams = (params: Record<string, unknown>) => {
+  return new URLSearchParams(
+    Object.entries(params).reduce(
+      (acc, [key, value]) => {
+        if (value === undefined || value === null) {
+          acc[key] = '';
+        } else if (Array.isArray(value)) {
+          // 배열
+          acc[key] = value.join(',');
+        } else if (typeof value === 'object') {
+          // 객체
+          acc[key] = JSON.stringify(value);
+        } else {
+          acc[key] = String(value);
+        }
+        return acc;
+      },
+      {} as Record<string, string>,
+    ),
+  ).toString();
+};


### PR DESCRIPTION
## 💻구현 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- `cookies-next` 라이브러리 추가
- API 요청 시에 401 뜨는 경우 retry 및 access token 자동 갱신
- GET 요청시에 쿼리파라미터 위해 `createQueryParams `유틸 함수 추가
- 공통 타입 추가 `src/shared/types` 참고
- 예시 및 테스트용 공연 리스트 조회 api 추가
<br><br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br><br>

## #️⃣연관된 이슈

> 아래에 {이슈번호}를 작성해주세요
> <br>
> close #53
- https://github.com/Team-TicketMate/ticketmate-server/issues/210
<br><br>

## ⚠️코멘트

> 리뷰어에게 남길 코멘트가 있다면 작성해주세요
- API 관련해서는 해당 폴더 참고 부탁드립니다. `src\app\_shared\services`
- 개발환경의 경우 root 경로에 `.env.development.local` 파일생성 후 `NEXT_PUBLIC_ACCESS_TOKEN = 토큰 값` 형태로 추가해서 개발하실 수 있습니다.
<br><br>

## ✅Check List

- [X] PR 제목 규칙
- [X] 추가/수정사항
- [X] 이슈번호
