### PR TITLE
feat: 신청취소 & 거절 모달 추가 #64

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,7 +16,7 @@ const nextConfig: NextConfig = {
     return config;
   },
   images: {
-    domains: ['picsum.photos', 'placehold.co'],
+    domains: ['picsum.photos', 'placehold.co', 'ticketmate.site'],
   },
 };
 

--- a/src/app/concert/form/[id]/_shared/components/form/form.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form/form.tsx
@@ -14,19 +14,16 @@ export default function Form() {
   const { open, closeTop } = useModal();
   const handleOpenModal = () => {
     open({
-      id: 'example-modal',
+      id: 'form-modal',
       content: (
         <FormModal
           title="일반예매 신청이 완료되었습니다."
           message={`대리인이 수락하게 되면 매칭이 완료됩니다.\n매칭이 완료되면 채팅을 통해 이야기를 나눠보세요.`}
           onConfirm={async () => {
-            console.log('확인됨');
             await new Promise((resolve) => setTimeout(resolve, 1000));
-            console.log('작업 완료');
             closeTop();
           }}
           onCancel={() => {
-            console.log('취소됨');
             closeTop();
           }}
         />

--- a/src/app/history/_shared/components/form-card/form-card.tsx
+++ b/src/app/history/_shared/components/form-card/form-card.tsx
@@ -3,11 +3,14 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { useGetConcertDetail } from '@/app/concert/[id]/_shared/services/query';
+import { useModal } from '@/shared/components/modal/use-modal';
 import { APPLICATION_STATUS_LABEL_MAP } from '@/shared/constants/type-mapping';
 import { Form, ApplicationFormStatus } from '@/shared/types';
 
-// import { formatDate } from '@/shared/utils/dates';
 import styles from './form-card.module.scss';
+import CancelModal from '../modal/cancel-modal';
+import RejectedModal from '../modal/rejected-modal';
+// import { formatDate } from '@/shared/utils/dates';
 
 interface FormCardProps {
   formItem: Form;
@@ -26,6 +29,7 @@ const FormCard = ({ formItem }: FormCardProps) => {
   } = formItem;
 
   const { data: concertItem } = useGetConcertDetail({ concertId });
+  const { open, closeTop } = useModal();
 
   if (!concertItem) {
     return null;
@@ -38,6 +42,41 @@ const FormCard = ({ formItem }: FormCardProps) => {
 
   const isCurrent = applicationFormStatus === 'PENDING';
 
+  const handleOpenCancelModal = () => {
+    open({
+      id: 'cancel-modal',
+      content: (
+        <CancelModal
+          title="신청을 취소하시겠습니까?"
+          message={`취소 시 신청했던 내역은 \n과거신청내역에서 확인가능합니다.`}
+          onConfirm={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            closeTop();
+          }}
+          onCancel={() => {
+            closeTop();
+          }}
+        />
+      ),
+    });
+  };
+
+  const handleOpenRejectedModal = () => {
+    open({
+      id: 'rejected-modal',
+      content: (
+        <RejectedModal
+          title="대리인 닉네임님의 거절 사유"
+          description={`작성한 신청양식을 통해 동일한 대리인에게 다시 티켓팅을 의뢰할 수 있습니다.\n`}
+          reason={`수고비가 단가랑 맞지 않음`}
+          onConfirm={async () => {
+            await new Promise((resolve) => setTimeout(resolve, 1000));
+            closeTop();
+          }}
+        />
+      ),
+    });
+  };
   return (
     <>
       <Link href={`concert/form/${applicationFormId}`}>
@@ -69,7 +108,12 @@ const FormCard = ({ formItem }: FormCardProps) => {
             <div className={styles.footer_container}>
               {isCurrent ? (
                 <>
-                  <button className={styles.link}>신청취소</button>
+                  <button
+                    className={styles.link}
+                    onClick={handleOpenCancelModal}
+                  >
+                    신청취소
+                  </button>
                   <span className={styles.default}>{statusLabel}</span>
                 </>
               ) : (
@@ -84,7 +128,7 @@ const FormCard = ({ formItem }: FormCardProps) => {
                   )}
                   {statusKey === 'REJECTED' && (
                     <>
-                      <div />
+                      <div onClick={handleOpenRejectedModal} />
                       <span className={styles.rejected}>{statusLabel}</span>
                     </>
                   )}

--- a/src/app/history/_shared/components/form-card/form-card.tsx
+++ b/src/app/history/_shared/components/form-card/form-card.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { useGetConcertDetail } from '@/app/concert/[id]/_shared/services/query';
+import { MODAL_ID } from '@/shared/components/modal/modal-constants';
 import { useModal } from '@/shared/components/modal/use-modal';
 import { APPLICATION_STATUS_LABEL_MAP } from '@/shared/constants/type-mapping';
 import { Form, ApplicationFormStatus } from '@/shared/types';
@@ -44,7 +45,7 @@ const FormCard = ({ formItem }: FormCardProps) => {
 
   const handleOpenCancelModal = () => {
     open({
-      id: 'cancel-modal',
+      id: MODAL_ID.CANCEL_MODAL,
       content: (
         <CancelModal
           title="신청을 취소하시겠습니까?"
@@ -63,7 +64,7 @@ const FormCard = ({ formItem }: FormCardProps) => {
 
   const handleOpenRejectedModal = () => {
     open({
-      id: 'rejected-modal',
+      id: MODAL_ID.REJECTED_MODAL,
       content: (
         <RejectedModal
           title="대리인 닉네임님의 거절 사유"
@@ -128,7 +129,7 @@ const FormCard = ({ formItem }: FormCardProps) => {
                   )}
                   {statusKey === 'REJECTED' && (
                     <>
-                      <div onClick={handleOpenRejectedModal} />
+                      <button onClick={handleOpenRejectedModal} />
                       <span className={styles.rejected}>{statusLabel}</span>
                     </>
                   )}

--- a/src/app/history/_shared/components/modal/cancel-modal.tsx
+++ b/src/app/history/_shared/components/modal/cancel-modal.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import React from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import Button from '@/shared/components/button/functional-button/functional-button';
+import CustomModal from '@/shared/components/modal/custom-modal';
+
+interface CancelModalProps {
+  title: string;
+  message: string;
+  onConfirm?: () => Promise<void> | void;
+  onCancel?: () => void;
+}
+
+const CancelModal = ({
+  title,
+  message,
+  onConfirm,
+  onCancel,
+}: CancelModalProps) => {
+  const router = useRouter(); // useRouter 훅을 사용하여 라우팅 처리
+
+  const handleConfirm = async () => {
+    if (onConfirm) await onConfirm();
+    router.push(`/history`);
+  };
+
+  const handleCancel = () => {
+    if (onCancel) onCancel();
+    router.push('/history');
+  };
+
+  return (
+    <CustomModal>
+      <CustomModal.Title>{title}</CustomModal.Title>
+      <CustomModal.Description>{message}</CustomModal.Description>
+      <CustomModal.Action>
+        <Button size="medium" variant="back" onClick={handleConfirm}>
+          다음에
+        </Button>
+        <Button size="medium" variant="fill" onClick={handleCancel}>
+          취소하기
+        </Button>
+      </CustomModal.Action>
+    </CustomModal>
+  );
+};
+
+export default CancelModal;

--- a/src/app/history/_shared/components/modal/rejected-modal.module.scss
+++ b/src/app/history/_shared/components/modal/rejected-modal.module.scss
@@ -1,0 +1,6 @@
+@use '@/styles/index' as *;
+
+.reason {
+  @include title-sm;
+  color: var(--brandColor-main);
+}

--- a/src/app/history/_shared/components/modal/rejected-modal.tsx
+++ b/src/app/history/_shared/components/modal/rejected-modal.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import React from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import styles from '@/app/history/_shared/components/modal/rejected-modal.module.scss';
+import Button from '@/shared/components/button/functional-button/functional-button';
+import CustomModal from '@/shared/components/modal/custom-modal';
+
+interface REjectedModalProps {
+  title: string;
+  reason: string;
+  description?: string;
+  onConfirm?: () => Promise<void> | void;
+}
+
+const RejectedModal = ({
+  title,
+  reason,
+  description,
+  onConfirm,
+}: REjectedModalProps) => {
+  const router = useRouter(); // useRouter 훅을 사용하여 라우팅 처리
+
+  const handleConfirm = async () => {
+    if (onConfirm) await onConfirm();
+    router.push(`/history`);
+  };
+
+  return (
+    <CustomModal>
+      <CustomModal.Title>{title}</CustomModal.Title>
+      <CustomModal.Description>{description}</CustomModal.Description>
+      <CustomModal.Description>
+        <p className={styles.reason}>“{reason}”</p>
+      </CustomModal.Description>
+      <CustomModal.Action>
+        <Button size="large" variant="back" onClick={handleConfirm}>
+          확인했어요
+        </Button>
+      </CustomModal.Action>
+    </CustomModal>
+  );
+};
+
+export default RejectedModal;

--- a/src/app/history/_shared/components/modal/rejected-modal.tsx
+++ b/src/app/history/_shared/components/modal/rejected-modal.tsx
@@ -8,7 +8,7 @@ import styles from '@/app/history/_shared/components/modal/rejected-modal.module
 import Button from '@/shared/components/button/functional-button/functional-button';
 import CustomModal from '@/shared/components/modal/custom-modal';
 
-interface REjectedModalProps {
+interface RejectedModalProps {
   title: string;
   reason: string;
   description?: string;
@@ -20,7 +20,7 @@ const RejectedModal = ({
   reason,
   description,
   onConfirm,
-}: REjectedModalProps) => {
+}: RejectedModalProps) => {
   const router = useRouter(); // useRouter 훅을 사용하여 라우팅 처리
 
   const handleConfirm = async () => {

--- a/src/shared/components/modal/modal-constants.ts
+++ b/src/shared/components/modal/modal-constants.ts
@@ -1,0 +1,4 @@
+export const MODAL_ID = {
+  CANCEL_MODAL: 'cancel-modal',
+  REJECTED_MODAL: 'rejected-modal',
+};


### PR DESCRIPTION
## 💻구현 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

신청 취소 -> 신청 취소 모달 오픈
거절 사유 (현재는 빈값으로 지정되어있음 ) -> 거절 사유 모달 오픈
#64 
<br><br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br><br>

## #️⃣연관된 이슈

> 아래에 {이슈번호}를 작성해주세요
> <br>
> close #64 

<br><br>

## ⚠️코멘트

> 리뷰어에게 남길 코멘트가 있다면 작성해주세요

현재 신청내역 부분도 backend에서 수정중이라서 tab버튼을 클릭했을 떄의 방식으로 테스트 진행했습니다. 추후 backend에서 마무리 되는대로 수정할 예정입니다 

## ✅Check List

- [x] PR 제목 규칙
- [x] 추가/수정사항
- [x] 이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added modal dialogs for canceling applications and viewing rejection reasons.
  - Integrated confirmation and rejection modals with improved styling and navigation.
  - Introduced centralized modal ID constants for consistent referencing.
- **Bug Fixes**
  - Updated image domain restrictions to include `ticketmate.site`.
  - Removed console logs from form modal callbacks.
- **Chores**
  - Expanded allowed image domains for optimized image loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->