### PR TITLE
[feat] 신청폼 상세정보 type & api 수정

### DIFF
--- a/src/app/concert/[id]/_shared/components/concert-info/concert-info.tsx
+++ b/src/app/concert/[id]/_shared/components/concert-info/concert-info.tsx
@@ -18,6 +18,7 @@ import {
   calculateDday,
   getPerformancePeriod,
 } from '@/shared/utils/dates';
+import { getPreOpenInfo, getGeneralOpenInfo } from '@/shared/utils/tickets';
 
 import styles from './concert-info.module.scss';
 
@@ -48,12 +49,9 @@ const ConcertInfo = ({ concertItem }: ConcertInfoProps) => {
     concertDateInfoResponseList,
   );
 
-  const preOpen = ticketOpenDateInfoResponses?.find(
-    (info) => info.ticketOpenType === 'PRE_OPEN',
-  );
-  const generalOpen = ticketOpenDateInfoResponses?.find(
-    (info) => info.ticketOpenType === 'GENERAL_OPEN',
-  );
+  //선예매, 일반예매 계산
+  const preOpen = getPreOpenInfo(ticketOpenDateInfoResponses ?? []);
+  const generalOpen = getGeneralOpenInfo(ticketOpenDateInfoResponses ?? []);
 
   useEffect(() => {
     // 배경 높이 - 앱바 높이

--- a/src/app/concert/form/[id]/_shared/components/form-modal/form-modal.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form-modal/form-modal.tsx
@@ -24,12 +24,12 @@ const FormModal = ({
 }: FormeModalProps) => {
   const router = useRouter(); // useRouter 훅을 사용하여 라우팅 처리
 
-  const handleCancel = async () => {
+  const handleConfirm = async () => {
     if (onConfirm) await onConfirm();
     router.push(`/concert/${concertId}`);
   };
 
-  const handleConfirm = () => {
+  const handleCheck = () => {
     if (onCancel) onCancel();
     router.push('/history');
   };
@@ -39,10 +39,10 @@ const FormModal = ({
       <CustomModal.Title>{title}</CustomModal.Title>
       <CustomModal.Description>{message}</CustomModal.Description>
       <CustomModal.Action>
-        <Button size="medium" variant="border" onClick={handleCancel}>
+        <Button size="medium" variant="border" onClick={handleConfirm}>
           확인했어요
         </Button>
-        <Button size="medium" variant="fill" onClick={handleConfirm}>
+        <Button size="medium" variant="fill" onClick={handleCheck}>
           신청내역 보러가기
         </Button>
       </CustomModal.Action>

--- a/src/app/concert/form/[id]/_shared/components/form-modal/form-modal.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form-modal/form-modal.tsx
@@ -12,6 +12,7 @@ interface FormeModalProps {
   message: string;
   onConfirm?: () => Promise<void> | void;
   onCancel?: () => void;
+  concertId: string;
 }
 
 const FormModal = ({
@@ -19,15 +20,16 @@ const FormModal = ({
   message,
   onConfirm,
   onCancel,
+  concertId,
 }: FormeModalProps) => {
   const router = useRouter(); // useRouter 훅을 사용하여 라우팅 처리
 
-  const handleConfirm = async () => {
+  const handleCancel = async () => {
     if (onConfirm) await onConfirm();
-    router.push(`/concert/:id`);
+    router.push(`/concert/${concertId}`);
   };
 
-  const handleCancel = () => {
+  const handleConfirm = () => {
     if (onCancel) onCancel();
     router.push('/history');
   };
@@ -37,10 +39,10 @@ const FormModal = ({
       <CustomModal.Title>{title}</CustomModal.Title>
       <CustomModal.Description>{message}</CustomModal.Description>
       <CustomModal.Action>
-        <Button size="medium" variant="border" onClick={handleConfirm}>
+        <Button size="medium" variant="border" onClick={handleCancel}>
           확인했어요
         </Button>
-        <Button size="medium" variant="fill" onClick={handleCancel}>
+        <Button size="medium" variant="fill" onClick={handleConfirm}>
           신청내역 보러가기
         </Button>
       </CustomModal.Action>

--- a/src/app/concert/form/[id]/_shared/components/form/form.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form/form.tsx
@@ -18,10 +18,11 @@ import FormTabManager from '../tab-button/manager/form-tab-manager';
 
 interface ConcertInfoProps {
   concertItem: Concert;
-  ticketOpenType?: TicketOpenType;
+  ticketOpenType: TicketOpenType;
+  concertId: string;
 }
 
-const Form = ({ concertItem, ticketOpenType }: ConcertInfoProps) => {
+const Form = ({ concertItem, ticketOpenType, concertId }: ConcertInfoProps) => {
   const { open, closeTop } = useModal();
   const {
     concertName,
@@ -49,9 +50,27 @@ const Form = ({ concertItem, ticketOpenType }: ConcertInfoProps) => {
   const startDate = sortedDates[0]?.performanceDate;
   const endDate = sortedDates[sortedDates.length - 1]?.performanceDate;
 
-  const selectedOpenInfo = ticketOpenDateInfoResponses.find(
-    (info) => info.ticketOpenType === ticketOpenType,
+  // 선택된 티켓 오픈 정보
+  const matchedOpenInfo = ticketOpenDateInfoResponses.find(
+    (item) => item.ticketOpenType === ticketOpenType,
   );
+
+  // 최대 예매 매수 구하기
+  const maxCount = matchedOpenInfo?.requestMaxCount ?? 1;
+
+  const countList = Array.from({ length: maxCount }, (_, i) => ({
+    value: (i + 1).toString(),
+    label: `${i + 1}매`,
+  }));
+
+  // 공연 날짜 리스트
+  const dateList = concertDateInfoResponseList.map((item) => {
+    const formatted = formatDate(item.performanceDate);
+    return {
+      value: formatted.split('(')[0],
+      label: `${formatted} (${item.session}회차)`,
+    };
+  });
 
   const handleOpenModal = () => {
     open({
@@ -80,7 +99,7 @@ const Form = ({ concertItem, ticketOpenType }: ConcertInfoProps) => {
           {ticketOpenType === 'GENERAL_OPEN' && (
             <Badge type="type-a">일반예매</Badge>
           )}
-          {selectedOpenInfo?.isBankTransfer && (
+          {matchedOpenInfo?.isBankTransfer && (
             <Badge type="type-b">무통장 가능</Badge>
           )}
         </div>
@@ -119,7 +138,13 @@ const Form = ({ concertItem, ticketOpenType }: ConcertInfoProps) => {
           </div>
         </div>
       </div>
-      <FormTabManager handleOpenModal={handleOpenModal} />
+      <FormTabManager
+        handleOpenModal={handleOpenModal}
+        dateList={dateList}
+        countList={countList}
+        ticketOpenType={ticketOpenType}
+        concertId={concertId}
+      />
     </div>
   );
 };

--- a/src/app/concert/form/[id]/_shared/components/form/form.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form/form.tsx
@@ -86,6 +86,7 @@ const Form = ({ concertItem, ticketOpenType, concertId }: ConcertInfoProps) => {
           onCancel={() => {
             closeTop();
           }}
+          concertId={concertId}
         />
       ),
     });

--- a/src/app/concert/form/[id]/_shared/components/form/form.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form/form.tsx
@@ -100,8 +100,10 @@ const Form = ({ concertItem, ticketOpenType, concertId }: ConcertInfoProps) => {
           {ticketOpenType === 'GENERAL_OPEN' && (
             <Badge type="type-a">일반예매</Badge>
           )}
-          {matchedOpenInfo?.isBankTransfer && (
+          {matchedOpenInfo?.isBankTransfer ? (
             <Badge type="type-b">무통장 가능</Badge>
+          ) : (
+            <Badge type="type-b">무통장 불가능</Badge>
           )}
         </div>
         <div className={styles.title}>{concertName}</div>

--- a/src/app/concert/form/[id]/_shared/components/form/form.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form/form.tsx
@@ -39,7 +39,7 @@ const Form = ({ concertItem, ticketOpenType, concertId }: ConcertInfoProps) => {
   const siteLabel = TICKET_SITE_LABEL_MAP[sitekey] ?? '기타';
 
   //공연 시작 날짜, 종료날짜 계산
-  const sortedDates = concertDateInfoResponseList
+  const sortedDates = (concertDateInfoResponseList || [])
     .slice()
     .sort(
       (a, b) =>
@@ -123,7 +123,9 @@ const Form = ({ concertItem, ticketOpenType, concertId }: ConcertInfoProps) => {
             <div className={styles.detail}>
               <span className={styles.category}>공연 일자</span>
               <span className={styles.info}>
-                {`${formatDate(startDate)} ~ ${formatDate(endDate)}`}
+                {startDate && endDate
+                  ? `${formatDate(startDate)} ~ ${formatDate(endDate)}`
+                  : '공연 날짜 미정'}
               </span>
             </div>
 

--- a/src/app/concert/form/[id]/_shared/components/form/form.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form/form.tsx
@@ -67,7 +67,7 @@ const Form = ({ concertItem, ticketOpenType, concertId }: ConcertInfoProps) => {
   const dateList = concertDateInfoResponseList.map((item) => {
     const formatted = formatDate(item.performanceDate);
     return {
-      value: formatted.split('(')[0],
+      value: item.performanceDate, // 원본 날짜 값 사용
       label: `${formatted} (${item.session}회차)`,
     };
   });

--- a/src/app/concert/form/[id]/_shared/components/form/form.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form/form.tsx
@@ -5,13 +5,54 @@ import Link from 'next/link';
 
 import Badge from '@/shared/components/badge/badge';
 import { useModal } from '@/shared/components/modal/use-modal';
+import {
+  TICKET_SITE_URL_MAP,
+  TICKET_SITE_LABEL_MAP,
+} from '@/shared/constants/type-mapping';
+import { TicketReservationSite, TicketOpenType, Concert } from '@/shared/types';
+import { formatDate } from '@/shared/utils/dates';
 
 import styles from './form.module.scss';
 import FormModal from '../form-modal/form-modal';
 import FormTabManager from '../tab-button/manager/form-tab-manager';
 
-export default function Form() {
+interface ConcertInfoProps {
+  concertItem: Concert;
+  ticketOpenType?: TicketOpenType;
+}
+
+const Form = ({ concertItem, ticketOpenType }: ConcertInfoProps) => {
   const { open, closeTop } = useModal();
+  const {
+    concertName,
+    concertHallName,
+    ticketReservationSite,
+    ticketOpenDateInfoResponses,
+    concertThumbnailUrl,
+    concertDateInfoResponseList,
+  } = concertItem;
+
+  //type별 url과 사이트 이름 변환
+  const sitekey = ticketReservationSite as TicketReservationSite;
+  const siteUrl = TICKET_SITE_URL_MAP[sitekey] ?? '#';
+  const siteLabel = TICKET_SITE_LABEL_MAP[sitekey] ?? '기타';
+
+  //공연 시작 날짜, 종료날짜 계산
+  const sortedDates = concertDateInfoResponseList
+    .slice()
+    .sort(
+      (a, b) =>
+        new Date(a.performanceDate).getTime() -
+        new Date(b.performanceDate).getTime(),
+    );
+
+  const startDate = sortedDates[0]?.performanceDate;
+  const endDate = sortedDates[sortedDates.length - 1]?.performanceDate;
+
+  const selectedOpenInfo = ticketOpenDateInfoResponses.find(
+    (info) => info.ticketOpenType === ticketOpenType,
+  );
+
   const handleOpenModal = () => {
     open({
       id: 'form-modal',
@@ -35,19 +76,22 @@ export default function Form() {
     <div className={styles.container}>
       <div className={styles.title_container}>
         <div className={styles.tag}>
-          <Badge type="type-a">일반예매</Badge>
-          <Badge type="type-b">무통장 가능</Badge>
+          {ticketOpenType === 'PRE_OPEN' && <Badge type="type-a">선예매</Badge>}
+          {ticketOpenType === 'GENERAL_OPEN' && (
+            <Badge type="type-a">일반예매</Badge>
+          )}
+          {selectedOpenInfo?.isBankTransfer && (
+            <Badge type="type-b">무통장 가능</Badge>
+          )}
         </div>
-        <div className={styles.title}>
-          터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ’
-        </div>
+        <div className={styles.title}>{concertName}</div>
         <div className={styles.info_container}>
           <div className={styles.image}>
             {/* 추후 next의 Image 로 변경 예정 */}
             <Image
               className={styles.image}
-              src={'https://picsum.photos/1366/768'}
-              alt="터치드(TOUCHED) 단독 콘서트 ‘HIGHLIGHT Ⅲ"
+              src={concertThumbnailUrl}
+              alt={concertName}
               width={140}
               height={186}
             />
@@ -56,18 +100,20 @@ export default function Form() {
           <div className={styles.detail_container}>
             <div className={styles.detail}>
               <span className={styles.category}>공연 일자</span>
-              <span className={styles.info}>24/08/27 ~ 24/09/26</span>
+              <span className={styles.info}>
+                {`${formatDate(startDate)} ~ ${formatDate(endDate)}`}
+              </span>
             </div>
 
             <div className={styles.detail}>
               <span className={styles.category}>공연장</span>
-              <span className={styles.info}>올림픽공원 핸드볼 경기장</span>
+              <span className={styles.info}>{concertHallName}</span>
             </div>
 
             <div className={styles.detail}>
               <span className={styles.category}>예매처</span>
-              <Link className={styles.link} href="https://ticket.yes24.com">
-                YES24
+              <Link className={styles.link} href={siteUrl}>
+                {siteLabel}
               </Link>
             </div>
           </div>
@@ -76,4 +122,6 @@ export default function Form() {
       <FormTabManager handleOpenModal={handleOpenModal} />
     </div>
   );
-}
+};
+
+export default Form;

--- a/src/app/concert/form/[id]/_shared/components/form/form.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form/form.tsx
@@ -11,6 +11,11 @@ import {
 } from '@/shared/constants/type-mapping';
 import { TicketReservationSite, TicketOpenType, Concert } from '@/shared/types';
 import { formatDate } from '@/shared/utils/dates';
+import {
+  getTicketOpenInfoByType,
+  getPreOpenInfo,
+  getGeneralOpenInfo,
+} from '@/shared/utils/tickets';
 
 import styles from './form.module.scss';
 import FormModal from '../form-modal/form-modal';
@@ -51,8 +56,11 @@ const Form = ({ concertItem, ticketOpenType, concertId }: ConcertInfoProps) => {
   const endDate = sortedDates[sortedDates.length - 1]?.performanceDate;
 
   // 선택된 티켓 오픈 정보
-  const matchedOpenInfo = ticketOpenDateInfoResponses.find(
-    (item) => item.ticketOpenType === ticketOpenType,
+  const preOpen = getPreOpenInfo(ticketOpenDateInfoResponses ?? []);
+  const generalOpen = getGeneralOpenInfo(ticketOpenDateInfoResponses ?? []);
+  const matchedOpenInfo = getTicketOpenInfoByType(
+    ticketOpenDateInfoResponses,
+    ticketOpenType,
   );
 
   // 최대 예매 매수 구하기
@@ -96,10 +104,8 @@ const Form = ({ concertItem, ticketOpenType, concertId }: ConcertInfoProps) => {
     <div className={styles.container}>
       <div className={styles.title_container}>
         <div className={styles.tag}>
-          {ticketOpenType === 'PRE_OPEN' && <Badge type="type-a">선예매</Badge>}
-          {ticketOpenType === 'GENERAL_OPEN' && (
-            <Badge type="type-a">일반예매</Badge>
-          )}
+          {preOpen && <Badge type="type-a">선예매</Badge>}
+          {generalOpen && <Badge type="type-a">일반예매</Badge>}
           {matchedOpenInfo?.isBankTransfer ? (
             <Badge type="type-b">무통장 가능</Badge>
           ) : (

--- a/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
+++ b/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useRef } from 'react';
 
 import { MinusIcon, PlusIcon, HelpCircleIcon } from '@/assets/icons';
 import Input from '@/shared/components/input/input';
+import { customToast } from '@/shared/components/toast/custom-toast/custom-toast';
 
 import styles from './form-input.module.scss';
 import { FormData, HopeArea } from './form-input.type';
@@ -43,10 +44,15 @@ export default function FormInput({
   }, [performanceDate, requestCount, hopeAreaList, requestDetails]);
 
   const addInput = () => {
-    setHopeAreaList((prev) => [
-      ...prev,
-      { id: Date.now(), location: '', price: '' },
-    ]);
+    setHopeAreaList((prev) => {
+      if (prev.length >= 10) {
+        customToast({
+          description: '최대 10개까지만 가능합니다.',
+        });
+        return prev;
+      }
+      return [...prev, { id: Date.now(), location: '', price: '' }];
+    });
   };
 
   const removeInput = (id: number) => {

--- a/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
+++ b/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
@@ -4,36 +4,52 @@ import { MinusIcon, PlusIcon, HelpCircleIcon } from '@/assets/icons';
 import Input from '@/shared/components/input/input';
 
 import styles from './form-input.module.scss';
-import { FormData, InputItem, dateList, countList } from './form-input.type';
+import { FormData, HopeArea } from './form-input.type';
 import FormSelect from '../select/form-select';
 
 interface FormInputProps {
   value: FormData;
   onChange: (data: FormData) => void;
+  dateList: { value: string; label: string }[];
+  countList: { value: string; label: string }[];
 }
 
-export default function FormInput({ value, onChange }: FormInputProps) {
-  const [inputs, setInputs] = useState<InputItem[]>(
-    value?.inputs || [{ id: 1, seat: '', price: '' }],
+export default function FormInput({
+  value,
+  onChange,
+  dateList,
+  countList,
+}: FormInputProps) {
+  const [hopeAreaList, setHopeAreaList] = useState<HopeArea[]>(
+    value?.hopeAreaList || [{ id: 1, location: '', price: '' }],
   );
-  const [date, setDate] = useState<string>(value?.date || '');
-  const [count, setCount] = useState<string>(value?.count || '');
-  const [note, setNote] = useState<string>(value?.note || '');
+  const [performanceDate, setPerformanceDate] = useState<string>(
+    value?.performanceDate || '',
+  );
+  const [requestCount, setRequestCount] = useState<string>(
+    value?.requestCount || '',
+  );
+  const [requestDetails, setRequestDetails] = useState<string>(
+    value?.requestDetails || '',
+  );
 
   useEffect(() => {
-    onChange({ inputs, date, count, note });
-  }, [inputs, date, count, note]);
+    onChange({ performanceDate, requestCount, hopeAreaList, requestDetails });
+  }, [performanceDate, requestCount, hopeAreaList, requestDetails]);
 
   const addInput = () => {
-    setInputs((prev) => [...prev, { id: Date.now(), seat: '', price: '' }]);
+    setHopeAreaList((prev) => [
+      ...prev,
+      { id: Date.now(), location: '', price: '' },
+    ]);
   };
 
   const removeInput = (id: number) => {
-    setInputs((prev) => prev.filter((input) => input.id !== id));
+    setHopeAreaList((prev) => prev.filter((input) => input.id !== id));
   };
 
   const handleInputChange = (id: number, field: string, value: string) => {
-    setInputs((prev) =>
+    setHopeAreaList((prev) =>
       prev.map((input) =>
         input.id === id ? { ...input, [field]: value } : input,
       ),
@@ -46,14 +62,22 @@ export default function FormInput({ value, onChange }: FormInputProps) {
         <span className={styles.span}>
           회차<span className={styles.asterisk}>*</span>
         </span>
-        <FormSelect selectList={dateList} value={date} onChange={setDate} />
+        <FormSelect
+          selectList={dateList}
+          value={performanceDate}
+          onChange={setPerformanceDate}
+        />
       </div>
 
       <div className={styles.form_container}>
         <span className={styles.span}>
           매수<span className={styles.asterisk}>*</span>
         </span>
-        <FormSelect selectList={countList} value={count} onChange={setCount} />
+        <FormSelect
+          selectList={countList}
+          value={requestCount}
+          onChange={setRequestCount}
+        />
       </div>
 
       <div className={styles.form_container}>
@@ -65,7 +89,7 @@ export default function FormInput({ value, onChange }: FormInputProps) {
           </div>
         </div>
 
-        {inputs.map((input, index) => (
+        {hopeAreaList.map((input, index) => (
           <div key={input.id} className={styles.input_container}>
             <span className={styles.text}>{`${index + 1}순위`}</span>
             {/* 구역명 입력 */}
@@ -73,9 +97,9 @@ export default function FormInput({ value, onChange }: FormInputProps) {
               label="구역명"
               placeholder="구역명"
               id={`seat-${input.id}`}
-              value={input.seat}
+              value={input.location}
               onChange={(e) =>
-                handleInputChange(input.id, 'seat', e.target.value)
+                handleInputChange(input.id, 'location', e.target.value)
               }
             />
 
@@ -89,7 +113,7 @@ export default function FormInput({ value, onChange }: FormInputProps) {
                 handleInputChange(input.id, 'price', e.target.value)
               }
             />
-            {index === inputs.length - 1 ? (
+            {index === hopeAreaList.length - 1 ? (
               <PlusIcon
                 width={16}
                 height={16}
@@ -115,8 +139,8 @@ export default function FormInput({ value, onChange }: FormInputProps) {
         <textarea
           className={styles.textarea}
           placeholder="자유롭게 입력해주세요."
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
+          value={requestDetails}
+          onChange={(e) => setRequestDetails(e.target.value)}
         />
       </div>
     </div>

--- a/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
+++ b/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 
 import { MinusIcon, PlusIcon, HelpCircleIcon } from '@/assets/icons';
 import Input from '@/shared/components/input/input';
@@ -33,9 +33,14 @@ export default function FormInput({
     value?.requestDetails || '',
   );
 
+  const isFirstRender = useRef(true);
   useEffect(() => {
+    if (isFirstRender.current) {
+      isFirstRender.current = false;
+      return;
+    }
     onChange({ performanceDate, requestCount, hopeAreaList, requestDetails });
-  }, [performanceDate, requestCount, hopeAreaList, requestDetails, onChange]);
+  }, [performanceDate, requestCount, hopeAreaList, requestDetails]);
 
   const addInput = () => {
     setHopeAreaList((prev) => [

--- a/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
+++ b/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
@@ -35,7 +35,7 @@ export default function FormInput({
 
   useEffect(() => {
     onChange({ performanceDate, requestCount, hopeAreaList, requestDetails });
-  }, [performanceDate, requestCount, hopeAreaList, requestDetails]);
+  }, [performanceDate, requestCount, hopeAreaList, requestDetails, onChange]);
 
   const addInput = () => {
     setHopeAreaList((prev) => [
@@ -45,7 +45,10 @@ export default function FormInput({
   };
 
   const removeInput = (id: number) => {
-    setHopeAreaList((prev) => prev.filter((input) => input.id !== id));
+    setHopeAreaList((prev) => {
+      if (prev.length <= 1) return prev; // 최소 1개는 유지
+      return prev.filter((input) => input.id !== id);
+    });
   };
 
   const handleInputChange = (id: number, field: string, value: string) => {

--- a/src/app/concert/form/[id]/_shared/components/input/form-input.type.ts
+++ b/src/app/concert/form/[id]/_shared/components/input/form-input.type.ts
@@ -1,24 +1,12 @@
-export type InputItem = {
-  seat: string;
-  price: string;
+export type HopeArea = {
   id: number;
+  location: string;
+  price: string; // 나중에 전송 시 Number로 변환
 };
 
 export type FormData = {
-  inputs: InputItem[];
-  date: string;
-  count: string;
-  note: string;
+  performanceDate: string; // 기존: date
+  requestCount: string; // 기존: count
+  hopeAreaList: HopeArea[]; // 기존: inputs
+  requestDetails: string; // 기존: note
 };
-
-export const dateList = [
-  { value: '2024-12-01', label: '2024/12/01(금) (1회차)' },
-  { value: '2024-12-02', label: '2024/12/02(토) (2회차)' },
-  { value: '2024-12-03', label: '2024/12/03(일) (3회차)' },
-];
-
-export const countList = [
-  { value: '1', label: '1매' },
-  { value: '2', label: '2매' },
-  { value: '3', label: '3매' },
-];

--- a/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
+++ b/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import FormInput from '@/app/concert/form/[id]/_shared/components/input/form-input';
 import { FormData } from '@/app/concert/form/[id]/_shared/components/input/form-input.type';
@@ -28,13 +28,14 @@ export default function FormTabManager({
   const [activeTab, setActiveTab] = useState(1);
   const [nextId, setNextId] = useState(2);
 
+  // FormData 형태로 초기화
   const [formData, setFormData] = useState<Record<number, FormData>>({
     1: {
       performanceDate: '',
       requestCount: '',
       hopeAreaList: [{ id: 1, location: '', price: '' }],
       requestDetails: '',
-    }, // FormData 형태로 초기화
+    },
   });
 
   const addNewTab = () => {
@@ -63,9 +64,9 @@ export default function FormTabManager({
     setFormData(newFormData);
   };
 
-  const updateFormData = (id: number, data: FormData) => {
+  const updateFormData = useCallback((id: number, data: FormData) => {
     setFormData((prev) => ({ ...prev, [id]: data }));
-  };
+  }, []);
 
   const getTabLabel = (tabId: number) => {
     const tabData = formData[tabId];

--- a/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
+++ b/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
@@ -1,22 +1,28 @@
 import { useState } from 'react';
 
 import FormInput from '@/app/concert/form/[id]/_shared/components/input/form-input';
-import {
-  dateList,
-  FormData,
-} from '@/app/concert/form/[id]/_shared/components/input/form-input.type';
+import { FormData } from '@/app/concert/form/[id]/_shared/components/input/form-input.type';
 import { useCreateConcertForm } from '@/app/concert/form/[id]/_shared/services/mutation';
 import { PlusIcon, CloseIcon } from '@/assets/icons';
 import Button from '@/shared/components/button/functional-button/functional-button';
+import { TicketOpenType } from '@/shared/types';
 
 import styles from './form-tab-manager.module.scss';
 import FormTabButton from '../button/form-tab-button';
 
 interface FormTabManagerProps {
   handleOpenModal: () => void;
+  dateList: { value: string; label: string }[];
+  countList: { value: string; label: string }[];
+  ticketOpenType: TicketOpenType;
+  concertId: string;
 }
 export default function FormTabManager({
   handleOpenModal,
+  dateList,
+  countList,
+  ticketOpenType,
+  concertId,
 }: FormTabManagerProps) {
   const [tabs, setTabs] = useState([1]);
   const [activeTab, setActiveTab] = useState(1);

--- a/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
+++ b/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
@@ -30,10 +30,10 @@ export default function FormTabManager({
 
   const [formData, setFormData] = useState<Record<number, FormData>>({
     1: {
-      date: '',
-      count: '',
-      inputs: [{ id: 1, seat: '', price: '' }],
-      note: '',
+      performanceDate: '',
+      requestCount: '',
+      hopeAreaList: [{ id: 1, location: '', price: '' }],
+      requestDetails: '',
     }, // FormData 형태로 초기화
   });
 
@@ -43,10 +43,10 @@ export default function FormTabManager({
     setFormData((prev) => ({
       ...prev,
       [nextId]: {
-        date: '',
-        count: '',
-        inputs: [{ id: 1, seat: '', price: '' }],
-        note: '',
+        performanceDate: '',
+        requestCount: '',
+        hopeAreaList: [{ id: 1, location: '', price: '' }],
+        requestDetails: '',
       },
     }));
     setNextId((id) => id + 1);
@@ -69,7 +69,9 @@ export default function FormTabManager({
 
   const getTabLabel = (tabId: number) => {
     const tabData = formData[tabId];
-    const selectedDate = dateList.find((item) => item.value === tabData?.date);
+    const selectedDate = dateList.find(
+      (item) => item.value === tabData?.performanceDate,
+    );
     return selectedDate ? selectedDate.label : '회차를 선택해주세요';
   };
 
@@ -80,23 +82,25 @@ export default function FormTabManager({
 
     // CreateConcertFormRequest 타입에 맞게 수정된 데이터 구조
     const requestBody = {
-      agentId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-      concertId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-      performanceDate: currentFormData.date,
-      requestCount: Number(currentFormData.count),
-      hopeAreaList: currentFormData.inputs.map((item, index) => ({
-        priority: index + 1,
-        location: item.seat,
-        price: Number(item.price),
-      })),
-      requestDetails: currentFormData.note,
-      isPreOpen: false,
+      agentId: '3fa85f64-5717-4562-b3fc-2c963f66afa6', //moak agentId로 연결
+      concertId,
+      ticketOpenType,
+      applicationFormDetailRequestList: [
+        {
+          performanceDate: currentFormData.performanceDate,
+          requestCount: Number(currentFormData.requestCount),
+          hopeAreaList: currentFormData.hopeAreaList.map((item, index) => ({
+            priority: index + 1,
+            location: item.location,
+            price: Number(item.price),
+          })),
+          requestDetails: currentFormData.requestDetails,
+        },
+      ],
     };
 
     // requestBody를 콘솔에 출력하여 잘 생성되었는지 확인
     console.log('Request Body:', requestBody);
-
-    // mutate 함수 실행
     mutate(requestBody);
   };
 
@@ -137,6 +141,8 @@ export default function FormTabManager({
               key={tabId}
               value={formData[tabId]}
               onChange={(data) => updateFormData(tabId, data)}
+              dateList={dateList}
+              countList={countList}
             />
           ) : null,
         )}

--- a/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
+++ b/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
@@ -93,7 +93,7 @@ export default function FormTabManager({
     );
 
     const requestBody = {
-      agentId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+      agentId: 'a618fdf6-fa1d-431e-bbea-d3e4494e10f1',
       concertId,
       ticketOpenType,
       applicationFormDetailRequestList,

--- a/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
+++ b/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
@@ -78,28 +78,27 @@ export default function FormTabManager({
   const { mutate } = useCreateConcertForm();
 
   const handleSubmit = () => {
-    const currentFormData = formData[activeTab];
+    // formData의 모든 탭 데이터를 배열로 변환
+    const applicationFormDetailRequestList = Object.values(formData).map(
+      (currentFormData) => ({
+        performanceDate: currentFormData.performanceDate,
+        requestCount: Number(currentFormData.requestCount),
+        hopeAreaList: currentFormData.hopeAreaList.map((item, index) => ({
+          priority: index + 1,
+          location: item.location,
+          price: Number(item.price),
+        })),
+        requestDetails: currentFormData.requestDetails,
+      }),
+    );
 
-    // CreateConcertFormRequest 타입에 맞게 수정된 데이터 구조
     const requestBody = {
-      agentId: '3fa85f64-5717-4562-b3fc-2c963f66afa6', //moak agentId로 연결
+      agentId: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
       concertId,
       ticketOpenType,
-      applicationFormDetailRequestList: [
-        {
-          performanceDate: currentFormData.performanceDate,
-          requestCount: Number(currentFormData.requestCount),
-          hopeAreaList: currentFormData.hopeAreaList.map((item, index) => ({
-            priority: index + 1,
-            location: item.location,
-            price: Number(item.price),
-          })),
-          requestDetails: currentFormData.requestDetails,
-        },
-      ],
+      applicationFormDetailRequestList,
     };
 
-    // requestBody를 콘솔에 출력하여 잘 생성되었는지 확인
     console.log('Request Body:', requestBody);
     mutate(requestBody);
   };

--- a/src/app/concert/form/[id]/_shared/services/type.ts
+++ b/src/app/concert/form/[id]/_shared/services/type.ts
@@ -4,14 +4,21 @@ interface HopeArea {
   price: number; // 가격
 }
 
-interface CreateConcertFormRequest {
-  agentId: string; // 대리인 PK
-  concertId: string; // 콘서트 PK
+interface ApplicationFormDetailRequest {
   performanceDate: string; // 공연 일자
   requestCount: number; // 요청한 티켓 수
   hopeAreaList?: HopeArea[]; // 희망 구역 리스트 (선택)
   requestDetails?: string; // 요청 사항 (선택)
-  isPreOpen: boolean; // 선예매 여부
+}
+
+type TicketOpenType = 'PRE_OPEN' | 'GENERAL_OPEN';
+
+interface CreateConcertFormRequest {
+  agentId: string; // 대리인 PK
+  concertId: string; // 콘서트 PK
+  applicationFormDetailRequestList: ApplicationFormDetailRequest[]; // 신청 공연 회차 목록 [최소 1개 이상 필수]
+
+  ticketOpenType: TicketOpenType; // 선예매 여부
 }
 
 export type { CreateConcertFormRequest };

--- a/src/app/concert/form/[id]/page.tsx
+++ b/src/app/concert/form/[id]/page.tsx
@@ -1,17 +1,43 @@
 'use client';
+import { use } from 'react';
 
 import AppBarSetter from '@/shared/components/header/app-bar/app-bar-setter';
+import { TicketOpenType } from '@/shared/types';
 
 import Form from './_shared/components/form/form';
 import styles from './page.module.scss';
+import { useGetConcertDetail } from '../../[id]/_shared/services/query';
 
-export default function Page() {
+export default function Page({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ ticketOpenType?: string }>;
+}) {
+  const resolvedParams = use(params);
+  const resolvedSearchParams = use(searchParams);
+
+  const { id } = resolvedParams;
+
+  const ticketOpenType = resolvedSearchParams.ticketOpenType as TicketOpenType;
+
+  const { data: concertItem } = useGetConcertDetail(
+    id ? { concertId: id } : undefined,
+  );
+
   return (
     <>
       <AppBarSetter title="신청 양식" />
 
       <div className={styles.container}>
-        <Form />
+        {concertItem && (
+          <Form
+            concertItem={concertItem}
+            ticketOpenType={ticketOpenType}
+            concertId={id}
+          />
+        )}
       </div>
     </>
   );

--- a/src/shared/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/shared/components/bottom-sheet/bottom-sheet.tsx
@@ -47,14 +47,14 @@ const BottomSheet = ({
       </div>
       <div className={styles.button_container}>
         {preOpen && (
-          <Link href={`/concert/form/${concertId}`}>
+          <Link href={`/concert/form/${concertId}?ticketOpenType=PRE_OPEN`}>
             <Button size="large" variant="fill" onClick={onClose}>
               선예매 요청하기
             </Button>
           </Link>
         )}
         {generalOpen && (
-          <Link href={`/concert/form/${concertId}`}>
+          <Link href={`/concert/form/${concertId}?ticketOpenType=GENERAL_OPEN`}>
             <Button size="large" variant="border" onClick={onClose}>
               일반예매 요청하기
             </Button>

--- a/src/shared/types/concert.ts
+++ b/src/shared/types/concert.ts
@@ -50,4 +50,4 @@ interface Concert {
   seatingChartUrl: string; // 좌석 배치도 URL
 }
 
-export type { ConcertType, TicketReservationSite, Concert };
+export type { ConcertType, TicketReservationSite, Concert, TicketOpenType };

--- a/src/shared/types/concert.ts
+++ b/src/shared/types/concert.ts
@@ -50,4 +50,10 @@ interface Concert {
   seatingChartUrl: string; // 좌석 배치도 URL
 }
 
-export type { ConcertType, TicketReservationSite, Concert, TicketOpenType };
+export type {
+  ConcertType,
+  TicketReservationSite,
+  Concert,
+  TicketOpenType,
+  TicketOpenDateInfo,
+};

--- a/src/shared/utils/dates.ts
+++ b/src/shared/utils/dates.ts
@@ -12,12 +12,8 @@ export const formatDate = (date: string | number | Date): string => {
 
 //Open 날짜를 기준으로 디데이 계산
 export const calculateDday = (targetDate: string | number | Date): string => {
-  const today = new Date();
-  const formattedToday = formatDate(today);
-  const formattedTargetDate = formatDate(targetDate);
-
-  const todayDate = new Date(formattedToday);
-  const target = new Date(formattedTargetDate);
+  const todayDate = new Date();
+  const target = new Date(targetDate);
 
   // 시간을 00:00:00으로 맞추기
   todayDate.setHours(0, 0, 0, 0);

--- a/src/shared/utils/dates.ts
+++ b/src/shared/utils/dates.ts
@@ -4,7 +4,10 @@ export interface PerformanceDateInfo {
 
 // YYYY-MM-DD로 변환
 export const formatDate = (date: string | number | Date): string => {
-  return new Date(date).toLocaleDateString('en-CA');
+  const d = new Date(date);
+  const formattedDate = d.toLocaleDateString('en-CA'); // YYYY-MM-DD
+  const dayName = ['일', '월', '화', '수', '목', '금', '토'][d.getDay()];
+  return `${formattedDate} (${dayName})`;
 };
 
 //Open 날짜를 기준으로 디데이 계산

--- a/src/shared/utils/tickets.ts
+++ b/src/shared/utils/tickets.ts
@@ -1,0 +1,14 @@
+import { TicketOpenDateInfo, TicketOpenType } from '../types';
+
+export const getTicketOpenInfoByType = (
+  responses: TicketOpenDateInfo[] | undefined,
+  type: TicketOpenType,
+): TicketOpenDateInfo | undefined => {
+  return responses?.find((info) => info.ticketOpenType === type);
+};
+
+export const getPreOpenInfo = (responses: TicketOpenDateInfo[]) =>
+  getTicketOpenInfoByType(responses, 'PRE_OPEN');
+
+export const getGeneralOpenInfo = (responses: TicketOpenDateInfo[]) =>
+  getTicketOpenInfoByType(responses, 'GENERAL_OPEN');


### PR DESCRIPTION
## 💻구현 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- 수정된 type로 변경한 후 api도 맞게 수정 후 테스트
- 무통장 불가능 태그 추가
- performaceDate 기존에 전달되는 형식으로 request body에 들어가도록 형식 수정
- date에 요일 추가
- 여러개의 신청서를 하나의 배열로 전달하도록 수정 
- #71
<br><br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br><br>

## #️⃣연관된 이슈

> 아래에 {이슈번호}를 작성해주세요
> <br>
> close #71

<br><br>

## ⚠️코멘트

> 리뷰어에게 남길 코멘트가 있다면 작성해주세요

<br><br>

## ✅Check List

- [x] PR 제목 규칙
- [x] 추가/수정사항
- [x] 이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for selecting ticket open type (pre-open or general) when requesting concert tickets.
  - Users can now specify multiple hope areas and performance details in ticket request forms.
  - The ticket request form now supports submitting applications for multiple performance dates at once.

- **Enhancements**
  - Concert form UI dynamically displays concert details, ticket site links, and badges based on provided data.
  - Dates are now shown with the day of the week in Korean for improved clarity.
  - Navigation URLs for ticket requests now include ticket open type parameters for clearer context.
  - Form tabs aggregate and submit data across multiple sessions with updated field structures.

- **Bug Fixes**
  - Improved navigation and button actions in form modals for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->