### PR TITLE
의뢰인&대리인 입장에서 신청폼 거절/수락

### DIFF
--- a/src/app/_components/concert/concert-list/concert-list.tsx
+++ b/src/app/_components/concert/concert-list/concert-list.tsx
@@ -14,7 +14,7 @@ const ConcertList = () => {
   const [request, setRequest] = useState<GetConcertListRequest>({
     pageSize: 10,
     sortField: 'created_date',
-    sortDirection: 'DESC',
+    sortDirection: 'ASC',
   });
 
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =

--- a/src/app/concert/[id]/_shared/components/bottom-sheet/bottom-sheet.tsx
+++ b/src/app/concert/[id]/_shared/components/bottom-sheet/bottom-sheet.tsx
@@ -28,6 +28,7 @@ const BottomSheet = ({
 }: BottomSheetProps) => {
   const { ticketOpenDateInfoResponses } = concertItem ?? {};
 
+  //티켓 오픈 타입 별로 버튼 구분
   const preOpen = ticketOpenDateInfoResponses?.find(
     (info) => info.ticketOpenType === 'PRE_OPEN',
   );

--- a/src/app/concert/[id]/page.tsx
+++ b/src/app/concert/[id]/page.tsx
@@ -16,9 +16,10 @@ import { useScroll } from '@/shared/hooks/use-scroll';
 
 import styles from './page.module.scss';
 
+//고정된 대리인 ID(추후 삭제 예정)
 const FIXED_AGENT_ID = '194641e9-84da-43fb-a763-6ef41710f714';
 
-// Mock API 호출 함수
+// Mock API 호출 함수 (임시)
 const handleGetCard = async (pageParam: number) => {
   const mockData = Array.from({ length: 10 }, (_, index) => ({
     agentId: FIXED_AGENT_ID,
@@ -45,6 +46,7 @@ const Page = ({ params }: { params: Promise<{ id: string }> }) => {
     setIsBottomSheetOpen(!isBottomSheetOpen);
   };
 
+  // 특정 유저카드 클릭 시 바텀시트 열기
   const handleUserCardClick = (agentId: string) => {
     setSelectedAgentId(agentId);
     setIsBottomSheetOpen(true);
@@ -52,6 +54,7 @@ const Page = ({ params }: { params: Promise<{ id: string }> }) => {
 
   const { ref, inView } = useInView();
 
+  // 무한스크롤 데이터 fetch
   const {
     data: userData,
     fetchNextPage,

--- a/src/app/concert/[id]/page.tsx
+++ b/src/app/concert/[id]/page.tsx
@@ -17,7 +17,7 @@ import { useScroll } from '@/shared/hooks/use-scroll';
 import styles from './page.module.scss';
 
 //고정된 대리인 ID(추후 삭제 예정)
-const FIXED_AGENT_ID = '194641e9-84da-43fb-a763-6ef41710f714';
+const FIXED_AGENT_ID = '11d4486d-4524-4e21-8ec1-bffc764bc7bb';
 
 // Mock API 호출 함수 (임시)
 const handleGetCard = async (pageParam: number) => {

--- a/src/app/concert/form/[id]/_shared/components/form/form.module.scss
+++ b/src/app/concert/form/[id]/_shared/components/form/form.module.scss
@@ -11,7 +11,6 @@
   .title_container {
     position: relative;
     width: 100%;
-    margin-top: 40px;
 
     .tag {
       display: flex;

--- a/src/app/concert/form/[id]/_shared/components/form/form.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form/form.tsx
@@ -44,7 +44,7 @@ const Form = ({ concertItem, ticketOpenType }: ConcertInfoProps) => {
     concertDateInfoResponseList,
   );
 
-  // 선택된 티켓 오픈 정보
+  // 선택된 티켓 오픈 정보 (선예매 / 일반예매)
   const preOpen = getPreOpenInfo(ticketOpenDateInfoResponses ?? []);
   const generalOpen = getGeneralOpenInfo(ticketOpenDateInfoResponses ?? []);
   const matchedOpenInfo = getTicketOpenInfoByType(

--- a/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
+++ b/src/app/concert/form/[id]/_shared/components/input/form-input.tsx
@@ -16,6 +16,11 @@ import { getTicketOpenInfoByType } from '@/shared/utils/tickets';
 import styles from './form-input.module.scss';
 import { FormData, HopeArea } from './form-input.type';
 
+/**
+ * FormInput 컴포넌트
+ * 신청폼 작성 탭에서 회차/매수/희망구역/요청사항을 입력할 수 있는 폼 UI
+ */
+
 interface FormInputProps {
   value: FormData;
   onChange: (data: FormData) => void;
@@ -38,6 +43,7 @@ export default function FormInput({
   const firstDetail =
     formItem?.applicationFormDetailResponseList?.[currentIndex];
 
+  //희망사항 부분 초기세팅
   const [hopeAreaList, setHopeAreaList] = useState<HopeArea[]>(
     firstDetail?.hopeAreaResponseList?.map((area, idx) => ({
       id: idx + 1,
@@ -46,6 +52,7 @@ export default function FormInput({
     })) ??
       value?.hopeAreaList ?? [{ id: 1, location: '', price: '' }],
   );
+  //공연날짜, 매수, 요청사항 초기세팅 (작성된 신청폼이 있다면 데이터 불러오기)
   const [performanceDate, setPerformanceDate] = useState<string>(
     firstDetail?.performanceDate ?? value?.performanceDate ?? '',
   );
@@ -56,6 +63,7 @@ export default function FormInput({
     firstDetail?.requirement ?? value?.requirement ?? '',
   );
 
+  //무한로딩 에러 해결을 위해 useRef로 중복확인
   const isFirstRender = useRef(true);
   useEffect(() => {
     if (isFirstRender.current) {
@@ -65,6 +73,7 @@ export default function FormInput({
     onChange({ performanceDate, requestCount, hopeAreaList, requirement });
   }, [performanceDate, requestCount, hopeAreaList, requirement]);
 
+  //희망사항 추가
   const addInput = () => {
     setHopeAreaList((prev) => {
       if (prev.length >= 10) {
@@ -77,6 +86,7 @@ export default function FormInput({
     });
   };
 
+  //희망사항 삭제
   const removeInput = (id: number) => {
     setHopeAreaList((prev) => {
       if (prev.length <= 1) return prev; // 최소 1개는 유지
@@ -92,7 +102,7 @@ export default function FormInput({
     );
   };
 
-  // 공연 날짜 리스트
+  // 공연 날짜 옵션 리스트로 생성
   const dateList = concertDateInfoResponseList.map((item) => {
     const formatted = formatDate(item.performanceDate);
     return {
@@ -101,6 +111,7 @@ export default function FormInput({
     };
   });
 
+  //티켓 오픈 타입 매칭
   const matchedOpenInfo = getTicketOpenInfoByType(
     ticketOpenDateInfoResponses,
     ticketOpenType,
@@ -108,7 +119,6 @@ export default function FormInput({
 
   // 최대 예매 매수 구하기
   const maxCount = matchedOpenInfo?.requestMaxCount ?? 1;
-
   const countList = Array.from({ length: maxCount }, (_, i) => ({
     value: (i + 1).toString(),
     label: `${i + 1}매`,
@@ -147,6 +157,7 @@ export default function FormInput({
           </div>
         </div>
 
+        {/* 희망 구역 입력 정보 */}
         {hopeAreaList.map((input, index) => (
           <div key={input.id} className={styles.input_container}>
             <span className={styles.text}>{`${index + 1}순위`}</span>
@@ -192,6 +203,7 @@ export default function FormInput({
         ))}
       </div>
 
+      {/* 요청사항 입력 */}
       <div className={styles.form_container}>
         <span className={styles.span}>요청사항</span>
         <textarea

--- a/src/app/concert/form/[id]/_shared/components/readonly/form-readonly.tsx
+++ b/src/app/concert/form/[id]/_shared/components/readonly/form-readonly.tsx
@@ -7,6 +7,11 @@ import { getTicketOpenInfoByType } from '@/shared/utils/tickets';
 
 import styles from './form-readonly.module.scss';
 
+/**
+ * FormReadOnly 컴포넌트
+ * 기존 신청폼의 내용을 읽기 전용(readonly)으로 보여주는 폼 UI
+ */
+
 interface FormReadOnlyProps {
   concertDateInfoResponseList: ConcertDateInfo[];
   ticketOpenDateInfoResponses: TicketOpenDateInfo[];
@@ -22,13 +27,14 @@ export default function FormReadOnly({
 }: FormReadOnlyProps) {
   const { ticketOpenType, applicationFormDetailResponseList } = formItem;
 
+  // 탭(index)에 해당하는 신청폼 상세 데이터 추출
   const detail = applicationFormDetailResponseList[currentIndex];
   const performanceDate = detail.performanceDate;
   const requestCount = detail.requestCount.toString();
   const requirement = detail.requirement || '';
   const hopeAreaList = detail.hopeAreaResponseList || [];
 
-  // 공연 날짜 리스트
+  // 공연 날짜 옵션 리스트로 생성
   const dateList = concertDateInfoResponseList.map((item) => {
     const formatted = formatDate(item.performanceDate);
     return {
@@ -41,6 +47,8 @@ export default function FormReadOnly({
     ticketOpenDateInfoResponses,
     ticketOpenType,
   );
+
+  // 최대 예매 매수 구하기
   const maxCount = matchedOpenInfo?.requestMaxCount ?? 1;
   const countList = Array.from({ length: maxCount }, (_, i) => ({
     value: (i + 1).toString(),
@@ -72,6 +80,7 @@ export default function FormReadOnly({
           </div>
         </div>
 
+        {/* 희망 구역 입력 정보 (순위별로 location, price 비활성화 input 표시) */}
         {hopeAreaList.map((input, index) => (
           <div key={index} className={styles.input_container}>
             <span className={styles.text}>{`${index + 1}순위`}</span>

--- a/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
+++ b/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
@@ -1,8 +1,17 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import FormInput from '@/app/concert/form/[id]/_shared/components/input/form-input';
 import { FormData } from '@/app/concert/form/[id]/_shared/components/input/form-input.type';
+import FormReadOnly from '@/app/concert/form/[id]/_shared/components/readonly/form-readonly';
 import FormTabButton from '@/app/concert/form/[id]/_shared/components/tab-button/button/form-tab-button';
-import { useCreateConcertForm } from '@/app/concert/form/[id]/_shared/services/mutation';
+import {
+  useCreateConcertForm,
+  usePatchConcertForm,
+} from '@/app/concert/form/[id]/_shared/services/mutation';
+import {
+  CreateConcertFormRequest,
+  PatchConcertFormRequest,
+} from '@/app/concert/form/[id]/_shared/services/type';
 import { PlusIcon, CloseIcon } from '@/assets/icons';
 import Button from '@/shared/components/button/functional-button/functional-button';
 import { ERROR_MESSAGES } from '@/shared/constants/error-type';
@@ -15,8 +24,6 @@ import {
 import { formatDate } from '@/shared/utils/dates';
 
 import styles from './form-tab-manager.module.scss';
-import FormInput from '../../input/form-input';
-import FormReadOnly from '../../readonly/form-readonly';
 
 interface FormTabManagerProps {
   handleOpenModal: () => void;
@@ -40,9 +47,7 @@ export default function FormTabManager({
   const [activeTab, setActiveTab] = useState(1);
   const [nextId, setNextId] = useState(2);
   //status 별로 mode를 지정해서 렌더링 하는 form을 구분
-  const [mode, setMode] = useState<
-    'input' | 'readonly' | 'readApp' | undefined
-  >(() => {
+  const [mode] = useState<'input' | 'readonly' | 'readApp' | undefined>(() => {
     if (!status) return 'input';
     if (status === 'PENDING') return 'readonly';
     if (
@@ -54,6 +59,9 @@ export default function FormTabManager({
     // ACCEPTED 혹은 그 외의 상태는 undefined로 둬서 아무 동작 안 하도록
     return undefined;
   });
+  //input과 readapp을 구분해서 제출을 하기 위해 state로 관리
+  const [isEdit, setIsEdit] = useState(false);
+  const isEditing = mode === 'input' || (mode === 'readApp' && isEdit);
 
   // FormData 형태로 초기화
   const [formData, setFormData] = useState<Record<number, FormData>>({
@@ -156,7 +164,15 @@ export default function FormTabManager({
     setFormData((prev) => ({ ...prev, [id]: data }));
   }, []);
 
-  const { mutate } = useCreateConcertForm();
+  const { mutate: createMutate } = useCreateConcertForm();
+  const { mutate: patchMutate } = usePatchConcertForm();
+
+  const handleError = (error: unknown) => {
+    const code = error instanceof Error ? error.message : undefined;
+    const message =
+      (code && ERROR_MESSAGES[code]) || '알 수 없는 오류가 발생했습니다.';
+    onError(message);
+  };
 
   // 현재 모든 탭의 formData를 수집하여 신청 요청 API(mutate) 호출
   const handleSubmit = () => {
@@ -174,26 +190,35 @@ export default function FormTabManager({
       }),
     );
 
-    const requestBody = {
-      agentId: '194641e9-84da-43fb-a763-6ef41710f714',
-      concertId,
-      ticketOpenType,
-      applicationFormDetailRequestList,
-    };
+    if (mode === 'input') {
+      const requestBody: CreateConcertFormRequest = {
+        agentId: '11d4486d-4524-4e21-8ec1-bffc764bc7bb',
+        concertId,
+        ticketOpenType,
+        applicationFormDetailRequestList,
+      };
 
-    // mutate 함수 실행
-    mutate(requestBody, {
-      onSuccess: () => {
-        handleOpenModal();
-      },
-      onError: (error: unknown) => {
-        const code = error instanceof Error ? error.message : undefined;
-        const message =
-          (code && ERROR_MESSAGES[code]) || '알 수 없는 오류가 발생했습니다.';
-        onError(message);
-      },
-    });
+      createMutate(requestBody, {
+        onSuccess: () => handleOpenModal(),
+        onError: handleError,
+      });
+    } else if (mode === 'readApp') {
+      if (!formItem?.applicationFormId) {
+        return;
+      }
+
+      const requestBody: PatchConcertFormRequest = {
+        applicationFormId: formItem.applicationFormId,
+        applicationFormDetailRequestList,
+      };
+
+      patchMutate(requestBody, {
+        onSuccess: () => handleOpenModal(),
+        onError: handleError,
+      });
+    }
   };
+  console.log(mode);
 
   return (
     <div className={styles.container}>
@@ -205,7 +230,7 @@ export default function FormTabManager({
             isActive={activeTab === tabId}
             onClick={() => setActiveTab(tabId)}
             rightIcon={
-              mode === 'input' ? (
+              isEditing ? (
                 <div
                   className={styles.icon}
                   onClick={(e) => {
@@ -219,7 +244,7 @@ export default function FormTabManager({
             }
           />
         ))}
-        {mode === 'input' && (
+        {isEditing && (
           <FormTabButton
             label="추가하기"
             isActive={false}
@@ -232,7 +257,7 @@ export default function FormTabManager({
         <div>
           {tabs.map((tabId) =>
             activeTab === tabId ? (
-              mode === 'input' ? (
+              isEditing ? (
                 <FormInput
                   key={tabId}
                   value={formData[tabId]}
@@ -278,7 +303,13 @@ export default function FormTabManager({
             type="button"
             size="large"
             variant="fill"
-            onClick={() => setMode('input')}
+            onClick={() => {
+              if (isEditing) {
+                handleSubmit();
+              } else {
+                setIsEdit(true);
+              }
+            }}
           >
             재신청하기
           </Button>

--- a/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
+++ b/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
@@ -39,6 +39,7 @@ export default function FormTabManager({
   const [tabs, setTabs] = useState([1]);
   const [activeTab, setActiveTab] = useState(1);
   const [nextId, setNextId] = useState(2);
+  //status 별로 mode를 지정해서 렌더링 하는 form을 구분
   const [mode, setMode] = useState<
     'input' | 'readonly' | 'readApp' | undefined
   >(() => {
@@ -64,6 +65,9 @@ export default function FormTabManager({
     },
   });
 
+  // 기존 formItem이 존재하면 응답 리스트를 기반으로 탭 및 formData 상태를 초기화
+  // 탭 번호는 1부터 시작
+  // 각 탭의 formData는 performanceDate, requestCount, hopeAreaList 등의 정보를 포함
   useEffect(() => {
     if (
       formItem &&
@@ -98,12 +102,14 @@ export default function FormTabManager({
     }
   }, [formItem]);
 
+  // 탭 라벨 생성 함수
+  // 기존 신청폼이 있을 경우 공연 날짜 및 회차로 라벨 지정
+  // 없으면 기본 문구('회차를 선택해주세요') 표시
   const getTabLabel = (tabId: number) => {
     const formItemDate =
       formItem?.applicationFormDetailResponseList?.[tabId - 1]?.performanceDate;
 
     const date = formItemDate || formData[tabId - 1]?.performanceDate;
-
     if (!date) return '회차를 선택해주세요';
 
     const selectedDateInfo = concertItem.concertDateInfoResponseList.find(
@@ -116,6 +122,7 @@ export default function FormTabManager({
     return `${formatted} (${selectedDateInfo.session}회차)`;
   };
 
+  // 새로운 탭 추가 및 해당 탭에 대응되는 초기 formData 생성
   const addNewTab = () => {
     setTabs((prev) => [...prev, nextId]);
     setActiveTab(nextId);
@@ -131,6 +138,8 @@ export default function FormTabManager({
     setNextId((id) => id + 1);
   };
 
+  // 지정된 탭 ID를 제거하고, 해당 formData도 함께 삭제
+  // 삭제된 탭이 활성 탭일 경우, 가장 앞의 탭으로 포커스 이동
   const removeTab = (id: number) => {
     const newTabs = tabs.filter((tabId) => tabId !== id);
     setTabs(newTabs);
@@ -142,12 +151,14 @@ export default function FormTabManager({
     setFormData(newFormData);
   };
 
+  //여러개의 탭이 있을 경우 데이터 업데이트
   const updateFormData = useCallback((id: number, data: FormData) => {
     setFormData((prev) => ({ ...prev, [id]: data }));
   }, []);
 
   const { mutate } = useCreateConcertForm();
 
+  // 현재 모든 탭의 formData를 수집하여 신청 요청 API(mutate) 호출
   const handleSubmit = () => {
     // formData의 모든 탭 데이터를 배열로 변환
     const applicationFormDetailRequestList = Object.values(formData).map(

--- a/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
+++ b/src/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager.tsx
@@ -114,10 +114,11 @@ export default function FormTabManager({
   // 기존 신청폼이 있을 경우 공연 날짜 및 회차로 라벨 지정
   // 없으면 기본 문구('회차를 선택해주세요') 표시
   const getTabLabel = (tabId: number) => {
-    const formItemDate =
+    const currentFormDate = formData[tabId]?.performanceDate;
+    const fallbackDate =
       formItem?.applicationFormDetailResponseList?.[tabId - 1]?.performanceDate;
 
-    const date = formItemDate || formData[tabId - 1]?.performanceDate;
+    const date = currentFormDate || fallbackDate;
     if (!date) return '회차를 선택해주세요';
 
     const selectedDateInfo = concertItem.concertDateInfoResponseList.find(
@@ -209,7 +210,9 @@ export default function FormTabManager({
 
       const requestBody: PatchConcertFormRequest = {
         applicationFormId: formItem.applicationFormId,
-        applicationFormDetailRequestList,
+        applicationFormEditRequest: {
+          applicationFormDetailRequestList,
+        },
       };
 
       patchMutate(requestBody, {
@@ -218,7 +221,6 @@ export default function FormTabManager({
       });
     }
   };
-  console.log(mode);
 
   return (
     <div className={styles.container}>

--- a/src/app/concert/form/[id]/_shared/services/api.ts
+++ b/src/app/concert/form/[id]/_shared/services/api.ts
@@ -24,11 +24,11 @@ const createConcertForm = async (request: CreateConcertFormRequest) => {
  * @description 공연 신청폼 수정
  */
 const patchConcertForm = async (request: PatchConcertFormRequest) => {
-  const { applicationFormId, applicationFormDetailRequestList } = request;
+  const { applicationFormId, applicationFormEditRequest } = request;
 
   const data = await instance(`${BASE_URL}/${applicationFormId}`, {
     method: 'PATCH',
-    body: JSON.stringify(applicationFormDetailRequestList),
+    body: JSON.stringify(applicationFormEditRequest),
   });
 
   return data;

--- a/src/app/concert/form/[id]/_shared/services/api.ts
+++ b/src/app/concert/form/[id]/_shared/services/api.ts
@@ -1,5 +1,6 @@
 import {
   CreateConcertFormRequest,
+  PatchConcertFormRequest,
   GetFormDetailRequest,
   GetFormDetailResponse,
 } from '@/app/concert/form/[id]/_shared/services/type';
@@ -20,6 +21,20 @@ const createConcertForm = async (request: CreateConcertFormRequest) => {
 };
 
 /**
+ * @description 공연 신청폼 수정
+ */
+const patchConcertForm = async (request: PatchConcertFormRequest) => {
+  const { applicationFormId, applicationFormDetailRequestList } = request;
+
+  const data = await instance(`${BASE_URL}/${applicationFormId}`, {
+    method: 'PATCH',
+    body: JSON.stringify(applicationFormDetailRequestList),
+  });
+
+  return data;
+};
+
+/**
  * @description 공연 신청폼 개별 조회
  */
 const getFormDetail = async (request: GetFormDetailRequest) => {
@@ -34,4 +49,4 @@ const getFormDetail = async (request: GetFormDetailRequest) => {
   return data;
 };
 
-export { createConcertForm, getFormDetail };
+export { createConcertForm, patchConcertForm, getFormDetail };

--- a/src/app/concert/form/[id]/_shared/services/mutation.ts
+++ b/src/app/concert/form/[id]/_shared/services/mutation.ts
@@ -1,11 +1,17 @@
 import { useMutation } from '@tanstack/react-query';
 
-import { createConcertForm } from './api';
-import { CreateConcertFormRequest } from './type';
+import { createConcertForm, patchConcertForm } from './api';
+import { CreateConcertFormRequest, PatchConcertFormRequest } from './type';
 
 export const useCreateConcertForm = () => {
   return useMutation({
     mutationFn: (request: CreateConcertFormRequest) =>
       createConcertForm(request),
+  });
+};
+
+export const usePatchConcertForm = () => {
+  return useMutation({
+    mutationFn: (request: PatchConcertFormRequest) => patchConcertForm(request),
   });
 };

--- a/src/app/concert/form/[id]/_shared/services/type.ts
+++ b/src/app/concert/form/[id]/_shared/services/type.ts
@@ -1,4 +1,4 @@
-import { Form } from '@/shared/types';
+import { Form, TicketOpenType } from '@/shared/types';
 
 interface HopeArea {
   priority: number; // 우선순위
@@ -16,8 +16,6 @@ interface ApplicationFormDetail {
 interface ApplicationFormRequest {
   applicationFormDetailRequestList: ApplicationFormDetail[]; // 신청 공연 회차 목록
 }
-
-type TicketOpenType = 'PRE_OPEN' | 'GENERAL_OPEN';
 
 interface CreateConcertFormRequest extends ApplicationFormRequest {
   agentId: string; // 대리인 PK
@@ -45,48 +43,3 @@ export type {
   GetFormDetailRequest,
   GetFormDetailResponse,
 };
-
-//   import { Form } from '@/shared/types';
-
-// interface HopeArea {
-//   priority: number; // 우선순위
-//   location: string; // 구역명
-//   price: number; // 가격
-// }
-
-// interface ApplicationFormDetail{
-//   performanceDate: string; // 공연 일자
-//   requestCount: number; // 요청한 티켓 수
-//   hopeAreaList?: HopeArea[]; // 희망 구역 리스트 (선택)
-//   requestDetails?: string; // 요청 사항 (선택)
-// }
-
-// type TicketOpenType = 'PRE_OPEN' | 'GENERAL_OPEN';
-
-// interface CreateConcertFormRequest {
-//   agentId: string; // 대리인 PK
-//   concertId: string; // 콘서트 PK
-//   applicationFormDetailRequestList: ApplicationFormDetail[]; // 신청 공연 회차 목록 [최소 1개 이상 필수]
-
-//   ticketOpenType: TicketOpenType; // 선예매 여부
-// }
-
-// interface PatchConcertFormRequest {
-//   applicationFormId: string;
-//   applicationFormEditRequest: {
-//     applicationFormDetailRequestList: ApplicationFormDetail[];
-//   }; // 신청 공연 회차 목록 [최소 1개 이상 필수]
-// }
-
-// interface GetFormDetailRequest {
-//   applicationFormId: string; // 폼ID [필수]
-// }
-
-// type GetFormDetailResponse = Form;
-
-// export type {
-//   CreateConcertFormRequest,
-//   PatchConcertFormRequest,
-//   GetFormDetailRequest,
-//   GetFormDetailResponse,
-// };

--- a/src/app/concert/form/[id]/_shared/services/type.ts
+++ b/src/app/concert/form/[id]/_shared/services/type.ts
@@ -6,26 +6,28 @@ interface HopeArea {
   price: number; // 가격
 }
 
-interface ApplicationFormDetailRequest {
+interface ApplicationFormDetail {
   performanceDate: string; // 공연 일자
   requestCount: number; // 요청한 티켓 수
   hopeAreaList?: HopeArea[]; // 희망 구역 리스트 (선택)
   requestDetails?: string; // 요청 사항 (선택)
 }
 
+interface ApplicationFormRequest {
+  applicationFormDetailRequestList: ApplicationFormDetail[]; // 신청 공연 회차 목록
+}
+
 type TicketOpenType = 'PRE_OPEN' | 'GENERAL_OPEN';
 
-interface CreateConcertFormRequest {
+interface CreateConcertFormRequest extends ApplicationFormRequest {
   agentId: string; // 대리인 PK
   concertId: string; // 콘서트 PK
-  applicationFormDetailRequestList: ApplicationFormDetailRequest[]; // 신청 공연 회차 목록 [최소 1개 이상 필수]
-
   ticketOpenType: TicketOpenType; // 선예매 여부
 }
 
 interface PatchConcertFormRequest {
-  applicationFormId: string;
-  applicationFormDetailRequestList: ApplicationFormDetailRequest[]; // 신청 공연 회차 목록 [최소 1개 이상 필수]
+  applicationFormId: string; // 폼ID
+  applicationFormEditRequest: ApplicationFormRequest; // 신청 공연 회차 목록
 }
 
 interface GetFormDetailRequest {
@@ -35,8 +37,56 @@ interface GetFormDetailRequest {
 type GetFormDetailResponse = Form;
 
 export type {
+  HopeArea,
+  ApplicationFormDetail,
+  ApplicationFormRequest,
   CreateConcertFormRequest,
   PatchConcertFormRequest,
   GetFormDetailRequest,
   GetFormDetailResponse,
 };
+
+//   import { Form } from '@/shared/types';
+
+// interface HopeArea {
+//   priority: number; // 우선순위
+//   location: string; // 구역명
+//   price: number; // 가격
+// }
+
+// interface ApplicationFormDetail{
+//   performanceDate: string; // 공연 일자
+//   requestCount: number; // 요청한 티켓 수
+//   hopeAreaList?: HopeArea[]; // 희망 구역 리스트 (선택)
+//   requestDetails?: string; // 요청 사항 (선택)
+// }
+
+// type TicketOpenType = 'PRE_OPEN' | 'GENERAL_OPEN';
+
+// interface CreateConcertFormRequest {
+//   agentId: string; // 대리인 PK
+//   concertId: string; // 콘서트 PK
+//   applicationFormDetailRequestList: ApplicationFormDetail[]; // 신청 공연 회차 목록 [최소 1개 이상 필수]
+
+//   ticketOpenType: TicketOpenType; // 선예매 여부
+// }
+
+// interface PatchConcertFormRequest {
+//   applicationFormId: string;
+//   applicationFormEditRequest: {
+//     applicationFormDetailRequestList: ApplicationFormDetail[];
+//   }; // 신청 공연 회차 목록 [최소 1개 이상 필수]
+// }
+
+// interface GetFormDetailRequest {
+//   applicationFormId: string; // 폼ID [필수]
+// }
+
+// type GetFormDetailResponse = Form;
+
+// export type {
+//   CreateConcertFormRequest,
+//   PatchConcertFormRequest,
+//   GetFormDetailRequest,
+//   GetFormDetailResponse,
+// };

--- a/src/app/concert/form/[id]/_shared/services/type.ts
+++ b/src/app/concert/form/[id]/_shared/services/type.ts
@@ -23,6 +23,11 @@ interface CreateConcertFormRequest {
   ticketOpenType: TicketOpenType; // 선예매 여부
 }
 
+interface PatchConcertFormRequest {
+  applicationFormId: string;
+  applicationFormDetailRequestList: ApplicationFormDetailRequest[]; // 신청 공연 회차 목록 [최소 1개 이상 필수]
+}
+
 interface GetFormDetailRequest {
   applicationFormId: string; // 폼ID [필수]
 }
@@ -31,6 +36,7 @@ type GetFormDetailResponse = Form;
 
 export type {
   CreateConcertFormRequest,
+  PatchConcertFormRequest,
   GetFormDetailRequest,
   GetFormDetailResponse,
 };

--- a/src/app/concert/form/[id]/page.module.scss
+++ b/src/app/concert/form/[id]/page.module.scss
@@ -5,4 +5,5 @@
   flex-direction: column;
   width: 100%;
   gap: 40px;
+  padding: 40px 0;
 }

--- a/src/app/concert/form/[id]/page.tsx
+++ b/src/app/concert/form/[id]/page.tsx
@@ -25,7 +25,6 @@ export default function Page({
   const { id } = resolvedParams;
   const { open, closeTop } = useModal();
 
-  //현재 직렬처리로 되어있어서 로딩시간이 조금 길게 느껴짐, 추후 병렬처리 훅을 만들어서 개선해놓자
   const ticketOpenType = resolvedSearchParams.ticketOpenType as TicketOpenType;
   const status = resolvedSearchParams.status as ApplicationFormStatus;
 

--- a/src/app/concert/form/[id]/page.tsx
+++ b/src/app/concert/form/[id]/page.tsx
@@ -29,7 +29,7 @@ export default function Page({
   const ticketOpenType = resolvedSearchParams.ticketOpenType as TicketOpenType;
   const status = resolvedSearchParams.status as ApplicationFormStatus;
 
-  // status 존재 여부에 따른 분기(새로운 신청폼 / 기존신청폼)
+  // status 쿼리 존재 여부에 따른 분기(새로운 신청폼 / 기존 신청폼)
   const isApplicationFormPage = !!status;
   const applicationFormId = isApplicationFormPage ? id : undefined;
   const { data: formItem } = useGetFormDetail(
@@ -43,11 +43,6 @@ export default function Page({
   const { data: concertItem } = useGetConcertDetail(
     concertId ? { concertId } : undefined,
   );
-
-  const handleErrorToast = (message: string) =>
-    customToast({
-      description: message,
-    });
 
   const handleOpenModal = () => {
     open({
@@ -71,15 +66,21 @@ export default function Page({
 
   //useRef로 중복 확인 후 토스트 알림 한번만 뜨도록 설정
   const hasShownToast = useRef(false);
-  console.log(hasShownToast);
   useEffect(() => {
     if (status === 'PENDING' && !hasShownToast.current) {
       hasShownToast.current = true;
+      //formreadonly 첫 렌더링 때 나오는 수정불가능 토스트 알림
       customToast({
         description: `수정 불가능한 양식입니다.`,
       });
     }
   }, [status]);
+
+  //에러 발생 시 백엔드 에러 내용 필터링하여 토스트 알림
+  const handleErrorToast = (message: string) =>
+    customToast({
+      description: message,
+    });
 
   return (
     <>
@@ -91,12 +92,12 @@ export default function Page({
             <Form concertItem={concertItem} ticketOpenType={ticketOpenType} />
             <FormTabManager
               handleOpenModal={handleOpenModal}
-              concertItem={concertItem}
-              formItem={formItem}
+              concertItem={concertItem} //새로운 신청폼 작성 시 공연정보
+              formItem={formItem} //기존 신청폼 보여줄 시 공연데이터를 불러오기 위해 전달
               ticketOpenType={ticketOpenType}
               concertId={id}
               onError={handleErrorToast}
-              status={status}
+              status={status} //분기처리를 위해 전달
             />
           </>
         )}

--- a/src/app/concert/form/[id]/page.tsx
+++ b/src/app/concert/form/[id]/page.tsx
@@ -5,12 +5,12 @@ import AppBarSetter from '@/app/_components/layout/header/app-bar/app-bar-setter
 import { useGetConcertDetail } from '@/app/concert/[id]/_shared/services/concert/query';
 import Form from '@/app/concert/form/[id]/_shared/components/form/form';
 import FormModal from '@/app/concert/form/[id]/_shared/components/form-modal/form-modal';
+import FormTabManager from '@/app/concert/form/[id]/_shared/components/tab-button/manager/form-tab-manager';
+import { useGetFormDetail } from '@/app/concert/form/[id]/_shared/services/query';
 import { useModal } from '@/shared/components/modal/use-modal';
 import { customToast } from '@/shared/components/toast/custom-toast/custom-toast';
 import { TicketOpenType, ApplicationFormStatus } from '@/shared/types';
 
-import FormTabManager from './_shared/components/tab-button/manager/form-tab-manager';
-import { useGetFormDetail } from './_shared/services/query';
 import styles from './page.module.scss';
 
 export default function Page({

--- a/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
+++ b/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
@@ -11,6 +11,7 @@ import { useModal } from '@/shared/components/modal/use-modal';
 import { Form } from '@/shared/types';
 
 import styles from './agent-form-card.module.scss';
+import { usePutFormApprove, usePutFormReject } from '../../services/mutation';
 
 interface FormCardProps {
   formItem: Form;
@@ -24,6 +25,8 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
     concertId,
     applicationFormStatus,
   } = formItem;
+  const { mutate: approveForm } = usePutFormApprove();
+  const { mutate: rejectForm } = usePutFormReject();
 
   const { data: concertItem } = useGetConcertDetail({ concertId });
   const { open, closeTop } = useModal();
@@ -42,7 +45,7 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
           message={`의뢰인 닉네임의 요청을 수락할 시 의뢰인과 매칭이 성사되어 채팅이 가능해집니다`}
           confirmbtn={`수락`}
           onConfirm={async () => {
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            await approveForm({ applicationFormId });
             closeTop();
           }}
           onCancel={() => {
@@ -61,7 +64,7 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
           title="요청을 거절하시겠습니까?"
           description={`의뢰인 닉네임의 요청을 거절할 시 해당 신청내역이 삭제되고 복구할 수 없습니다.\n`}
           onConfirm={async () => {
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            await rejectForm({ applicationFormId });
             closeTop();
           }}
           onCancel={() => {

--- a/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
+++ b/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
@@ -5,13 +5,16 @@ import Link from 'next/link';
 import { useGetConcertDetail } from '@/app/concert/[id]/_shared/services/concert/query';
 import AcceptModal from '@/app/history/_shared/components/modal/common-modal';
 import RejectedModal from '@/app/history/_shared/components/modal/rejected-modal/rejected-modal';
+import {
+  usePutFormApprove,
+  usePutFormReject,
+} from '@/app/history/_shared/services/mutation';
 import Button from '@/shared/components/button/functional-button/functional-button';
 import { MODAL_ID } from '@/shared/components/modal/modal-constants';
 import { useModal } from '@/shared/components/modal/use-modal';
 import { Form } from '@/shared/types';
 
 import styles from './agent-form-card.module.scss';
-import { usePutFormApprove, usePutFormReject } from '../../services/mutation';
 
 interface FormCardProps {
   formItem: Form;

--- a/src/app/history/_shared/components/client-form-card/client-form-card.tsx
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.tsx
@@ -3,14 +3,14 @@ import Image from 'next/image';
 import Link from 'next/link';
 
 import { useGetConcertDetail } from '@/app/concert/[id]/_shared/services/concert/query';
+import CancelModal from '@/app/history/_shared/components/modal/common-modal';
+import ReasonModal from '@/app/history/_shared/components/modal/reason-modal/reason-modal';
 import { MODAL_ID } from '@/shared/components/modal/modal-constants';
 import { useModal } from '@/shared/components/modal/use-modal';
 import { APPLICATION_STATUS_LABEL_MAP } from '@/shared/constants/type-mapping';
 import { Form, ApplicationFormStatus } from '@/shared/types';
 
 import styles from './client-form-card.module.scss';
-import CancelModal from '../modal/common-modal';
-import ReasonModal from '../modal/reason-modal/reason-modal';
 // import { formatDate } from '@/shared/utils/dates';
 interface FormCardProps {
   formItem: Form;

--- a/src/app/history/_shared/components/history-list/history-list.tsx
+++ b/src/app/history/_shared/components/history-list/history-list.tsx
@@ -1,17 +1,20 @@
 'use client';
 
+import ClientFormCard from '@/app/history/_shared/components/client-form-card/client-form-card';
 import { useGetFormList } from '@/app/history/_shared/services/query';
 
 import styles from './history-list.module.scss';
-import ClientFormCard from '../client-form-card/client-form-card';
+//import AgentFormCard from '@/app/history/_shared/components//agent-form-card/agent-form-card';
 
 interface HistoryListProps {
   tab: 'current' | 'past';
 }
 
 const HistoryList = ({ tab }: HistoryListProps) => {
-  const { data } = useGetFormList();
-
+  //임시로 memberId 하드코딩
+  // const memberId = 'dd279013-29da-40ea-94af-9721a1abde74';
+  //현재는 모든 신청내역을 불러오고 있음 -> membertype & memberid로 본인의 기록만 가져오도록 수정필요
+  const { data } = useGetFormList({});
   const formList = data?.content ?? [];
 
   // tab 값에 따라 상태 기반 필터링

--- a/src/app/history/_shared/services/api.ts
+++ b/src/app/history/_shared/services/api.ts
@@ -1,6 +1,7 @@
 import {
   GetFormListRequest,
   GetFormListResponse,
+  PutFormRequest,
 } from '@/app/history/_shared/services/type';
 import instance from '@/shared/services/instance';
 import { createQueryParams } from '@/shared/utils/services/query-string';
@@ -21,4 +22,36 @@ const getFormList = async (request?: GetFormListRequest) => {
   return data;
 };
 
-export { getFormList };
+/**
+ * @description 공연 신청폼 수락
+ */
+const putFormApprove = async (request: PutFormRequest) => {
+  const { applicationFormId } = request;
+
+  const data = await instance(
+    `${BASE_URL}/expressions/${applicationFormId}/approve`,
+    {
+      method: 'PUT',
+    },
+  );
+
+  return data;
+};
+
+/**
+ * @description 공연 신청폼 거절
+ */
+const putFormReject = async (request: PutFormRequest) => {
+  const { applicationFormId } = request;
+
+  const data = await instance(
+    `${BASE_URL}/expressions/${applicationFormId}/reject`,
+    {
+      method: 'PUT',
+    },
+  );
+
+  return data;
+};
+
+export { getFormList, putFormApprove, putFormReject };

--- a/src/app/history/_shared/services/mutation.ts
+++ b/src/app/history/_shared/services/mutation.ts
@@ -1,0 +1,16 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { putFormApprove, putFormReject } from './api';
+import { PutFormRequest } from './type';
+
+export const usePutFormApprove = () => {
+  return useMutation({
+    mutationFn: (request: PutFormRequest) => putFormApprove(request),
+  });
+};
+
+export const usePutFormReject = () => {
+  return useMutation({
+    mutationFn: (request: PutFormRequest) => putFormReject(request),
+  });
+};

--- a/src/app/history/_shared/services/type.ts
+++ b/src/app/history/_shared/services/type.ts
@@ -14,4 +14,8 @@ interface GetFormListRequest {
 
 type GetFormListResponse = Pagination<Form>;
 
-export type { GetFormListRequest, GetFormListResponse };
+interface PutFormRequest {
+  applicationFormId: string;
+}
+
+export type { GetFormListRequest, GetFormListResponse, PutFormRequest };


### PR DESCRIPTION
## 💻구현 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- 코드 주석 작성 / 상대경로로 작성되어 있는 부분 절대경로로 변경
- 대리인 신청폼 수정 api 연동
- 의뢰인 신청폼 거절/수락 api 연동
- 신청폼 page 상,하단 간격 모두 생성되도록 수정
<br><br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 신청폼 수정 응답값이 변경되면서 type부분이 변경되었는데, 주석처리된 코드와 현재 주석처리가 되어있지 않는 코드 두가지 버전으로 작성해봤습니다. 어떤 코드가 더 괜찮을지 한번 봐주시면 감사하겠습니다! 
1. 주석 처리 된 부분 : 기존 코드에서 신청폼 수정 type만 변경
2. 주석처리 안 된 부분 : 공통부분을 별도로 type을 지정해서 신청폼 수정/생성에 적용

<br><br>

## #️⃣연관된 이슈

> 아래에 {이슈번호}를 작성해주세요
> <br>
> close #88

<br><br>

## ⚠️코멘트

> 리뷰어에게 남길 코멘트가 있다면 작성해주세요
- 현재 신청내역의 모든 기록이 불러와지고 있습니다. 추후 멤버타입과 멤버id로 구분하여 본인이 작성하거나, 본인에게 신청된 신청내역만 불러와지도록 수정할 예정입니다. 
<br><br>

## ✅Check List

- [x] PR 제목 규칙
- [x] 추가/수정사항
- [x] 이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for editing and updating existing concert application forms, including patching form data and managing editing state.
  * Introduced approve and reject actions for performance application forms, allowing agents to update form status directly from history.

* **Bug Fixes**
  * Replaced placeholder async delays with actual API calls for approve/reject actions in form status modals.

* **Improvements**
  * Enhanced code clarity and maintainability with detailed comments and documentation across multiple components.
  * Updated interface and type definitions for improved structure and consistency in form data handling.
  * Changed concert list sorting to display oldest concerts first.
  * Improved form tab management for more intuitive editing and reapplication workflows.
  * Increased vertical padding in concert form containers for better visual spacing.

* **Chores**
  * Refactored import paths to use absolute imports for consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->