### PR TITLE
페이지 이동 시 데이터 전달 가능한 navigation hook 추가

### DIFF
--- a/src/providers/context-provider.tsx
+++ b/src/providers/context-provider.tsx
@@ -1,0 +1,42 @@
+import { createElement, type ReactNode } from 'react';
+
+import { NavigationProvider } from '@/shared/context/navigation-context';
+
+/**
+ * `ContextProvider`는 애플리케이션에서 사용할 모든 전역 Context Provider들을 감싸는 컴포넌트입니다.
+ * 내부적으로 등록된 Provider들을 배열로 순회하여 계층적으로 children을 감싸며 반환합니다.
+ *
+ * 이 컴포넌트를 `app/layout.tsx`의 `<body>` 내부에 위치시키면,
+ * 하위 모든 컴포넌트에서 전역 상태를 사용할 수 있습니다.
+ *
+ * @param {Object} props
+ * @param {ReactNode} props.children - 하위에 렌더링될 자식 컴포넌트
+ *
+ * @returns {JSX.Element} 모든 Context Provider로 감싸진 컴포넌트 트리
+ *
+ * @example
+ * ```tsx
+ * // app/layout.tsx
+ * import ContextProvider from '@/shared/context/context-provider';
+ *
+ * export default function RootLayout({ children }: { children: ReactNode }) {
+ *   return (
+ *     <html lang="ko">
+ *       <body>
+ *         <ContextProvider>
+ *           {children}
+ *         </ContextProvider>
+ *       </body>
+ *     </html>
+ *   );
+ * }
+ * ```
+ */
+export default function ContextProvider({ children }: { children: ReactNode }) {
+  const contexts = [NavigationProvider];
+
+  return contexts.reduce(
+    (prev, context) => createElement(context, null, prev),
+    children,
+  );
+}

--- a/src/providers/index.tsx
+++ b/src/providers/index.tsx
@@ -1,5 +1,6 @@
-import { type ReactNode } from 'react';
+import React, { type ReactNode } from 'react';
 
+import ContextProvider from '@/providers/context-provider';
 import HeadProvider from '@/providers/head-provider';
 import ReactQueryProviders from '@/providers/react-query-provider';
 import ReactToastProvider from '@/providers/react-toast-provider';
@@ -9,7 +10,9 @@ const Provider = ({ children }: { children: ReactNode }) => {
   return (
     <>
       <HeadProvider />
-      <ReactQueryProviders>{children}</ReactQueryProviders>
+      <ReactQueryProviders>
+        <ContextProvider>{children}</ContextProvider>
+      </ReactQueryProviders>
       <StackModalProvider />
       <ReactToastProvider />
     </>

--- a/src/shared/context/navigation-context.tsx
+++ b/src/shared/context/navigation-context.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { createContext, ReactNode, useState, useMemo } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+export interface NavigateArgs<T> {
+  /** 경로 */
+  pathname: string;
+  /** 검색 쿼리 */
+  search?: string;
+  /** 상태 */
+  state?: T;
+}
+
+export interface NavigationContextType<T = unknown> {
+  /** 상태 */
+  state: T | null;
+  /** 상태 설정 */
+  setState: (data: T | null) => void;
+  /** 네비게이션 */
+  navigate: <T>(args: NavigateArgs<T>) => void;
+  /** 상태 소비(path에 넣은 페이지로 네비게이션하여 상태 return 이후, 상태 초기화) */
+  consume: () => T | null;
+}
+
+export const NavigationContext = createContext<
+  NavigationContextType | undefined
+>(undefined);
+
+export const NavigationProvider = ({ children }: { children: ReactNode }) => {
+  const router = useRouter();
+  const [state, setState] = useState<unknown>(null);
+
+  const navigate = <T,>({
+    pathname,
+    search = '',
+    state: newState,
+  }: NavigateArgs<T>) => {
+    if (newState !== undefined) setState(newState);
+
+    const searchParams = new URLSearchParams(search);
+    const fullPath = `${pathname}?${searchParams.toString()}`;
+    router.push(fullPath);
+  };
+
+  const consume = () => {
+    const data = state;
+    setState(null);
+    return data;
+  };
+
+  const value: NavigationContextType = useMemo(
+    () => ({
+      state,
+      setState,
+      navigate,
+      consume,
+    }),
+    [state],
+  );
+
+  return (
+    <NavigationContext.Provider value={value}>
+      {children}
+    </NavigationContext.Provider>
+  );
+};

--- a/src/shared/context/navigation-context.tsx
+++ b/src/shared/context/navigation-context.tsx
@@ -40,7 +40,9 @@ export const NavigationProvider = ({ children }: { children: ReactNode }) => {
     if (newState !== undefined) setState(newState);
 
     const searchParams = new URLSearchParams(search);
-    const fullPath = `${pathname}?${searchParams.toString()}`;
+    const queryString = searchParams.toString();
+    const fullPath = queryString ? `${pathname}?${queryString}` : pathname;
+
     router.push(fullPath);
   };
 

--- a/src/shared/hooks/navigation/use-location.ts
+++ b/src/shared/hooks/navigation/use-location.ts
@@ -1,0 +1,48 @@
+'use client';
+
+import { useContext, useEffect, useState } from 'react';
+
+import { useSearchParams } from 'next/navigation';
+
+import { NavigationContext } from '@/shared/context/navigation-context';
+
+/**
+ * `useLocation` 훅은 React Router의 `useLocation`과 유사한 역할을 하며,
+ * `navigate` 시 전달된 상태(`state`)와 현재 URL의 검색 쿼리(`searchParams`)를 반환합니다.
+ * 이때 state는 새로고침 시 초기화됩니다.
+ * @template T - navigate 시 전달한 상태(state)의 타입
+ *
+ * @returns {{
+ *   state: T | null;
+ *   searchParams: URLSearchParams;
+ * }}
+ * - `state`: `navigate()` 시 넘긴 제네릭 타입의 상태 값
+ * - `search`: URL 쿼리 파라미터 객체 (ex: `search.get("room")`)
+ *
+ * @example
+ * ```tsx
+ * const { state, searchParams } = useLocation<{ message: string }>();
+ * console.log(state?.message); // "hello"
+ * console.log(searchParams.get('room')); // "123"
+ * ```
+ *
+ * @throws `Error` - NavigationProvider 외부에서 사용 시 예외 발생
+ */
+export const useLocation = <T>() => {
+  const ctx = useContext(NavigationContext);
+  if (!ctx)
+    throw new Error('useLocation must be used within NavigationProvider');
+
+  /** 상태 */
+  const [state, setState] = useState<T | null>(() => ctx.consume() as T | null);
+  /** 검색 쿼리 */
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    if (state == null) {
+      setState(ctx.consume() as T | null);
+    }
+  }, []);
+
+  return { state, searchParams };
+};

--- a/src/shared/hooks/navigation/use-location.ts
+++ b/src/shared/hooks/navigation/use-location.ts
@@ -34,13 +34,15 @@ export const useLocation = <T>() => {
     throw new Error('useLocation must be used within NavigationProvider');
 
   /** 상태 */
-  const [state, setState] = useState<T | null>(() => ctx.consume() as T | null);
+  const [state, setState] = useState<T | null>(null);
   /** 검색 쿼리 */
   const searchParams = useSearchParams();
 
   useEffect(() => {
-    if (state == null) {
-      setState(ctx.consume() as T | null);
+    const consumedState = ctx.consume() as T | null;
+
+    if (consumedState !== null) {
+      setState(consumedState);
     }
   }, []);
 

--- a/src/shared/hooks/navigation/use-navigation.ts
+++ b/src/shared/hooks/navigation/use-navigation.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useContext } from 'react';
+
+import {
+  type NavigateArgs,
+  NavigationContext,
+} from '@/shared/context/navigation-context';
+
+/**
+ * `useNavigation` 훅은 React Router의 `useNavigate`와 유사한 역할을 하며,
+ * 페이지 이동 시 상태(`state`)를 함께 전달할 수 있는 기능을 제공합니다.
+ * 전달된 상태는 이동한 페이지에서 `useLocation()`을 통해 접근할 수 있습니다.
+ *
+ * @template T - navigate 시 전달할 상태 객체의 타입
+ *
+ * @returns {{
+ *   navigate: (args: NavigateArgs<T>) => void;
+ * }}
+ * - `navigate`: 상태와 함께 경로를 이동하는 함수
+ *
+ * @example
+ * ```tsx
+ * const { navigate } = useNavigation<{ message: string }>();
+ * navigate({
+ *   pathname: '/result',
+ *   search: '?step=2',
+ *   state: { message: '완료되었습니다.' },
+ * });
+ * ```
+ *
+ * @throws `Error` - NavigationProvider 외부에서 사용 시 예외 발생
+ */
+export const useNavigation = <T>() => {
+  const ctx = useContext(NavigationContext);
+  if (!ctx)
+    throw new Error('useNavigation must be used within NavigationProvider');
+
+  const navigate = (args: NavigateArgs<T>) => ctx.navigate<T>(args);
+
+  return { navigate };
+};


### PR DESCRIPTION
## 💻구현 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- 페이지 이동 시 state와 URL 쿼리파라미터를 함께 넘길 수 있는 `useNavigation`, `useLocation` 커스텀 훅 구현
- `navigate({ pathname, search, state })` 형태로 사용 가능
- 이동한 페이지에서 `useLocation()`을 통해 `state, search`에 접근 가능
- 여러 Context 를 구성하기 위한 ContextProvider 컴포넌트 추가


<br><br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br><br>

## #️⃣연관된 이슈

> 아래에 {이슈번호}를 작성해주세요
> <br>
> close #102

<br><br>

## ⚠️코멘트

> 리뷰어에게 남길 코멘트가 있다면 작성해주세요
- React Router Dom의 [useNavigate](https://reactrouter.com/api/hooks/useNavigate), [useLocation](https://reactrouter.com/api/hooks/useLocation#uselocation) 과 유사하게 구현하였습니다.
- 새로 만든 `useLocation` 과 `useNavigation` 훅 내부에 JSdoc으로 상세하게 주석을 달아놓았으니 사용법 관련하여 참고해보시면 될 것 같습니다.
<br><br>

## ✅Check List

- [x] PR 제목 규칙
- [x] 추가/수정사항
- [x] 이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Introduced a centralized provider component to wrap multiple global context providers for easier state management.
  * Added a navigation context to manage navigation state and actions across the application.
  * Implemented a hook to access navigation state and URL search parameters, similar to React Router's `useLocation`.
  * Added a hook for programmatic navigation with state passing, similar to React Router's `useNavigate`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->