### PR TITLE
거절 사유 조회 api 요청값 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
   sassOptions: {
     includePaths: [path.join(__dirname, 'styles')],
   },
@@ -12,7 +11,6 @@ const nextConfig: NextConfig = {
       test: /\.svg$/,
       use: ['@svgr/webpack'],
     });
-
     return config;
   },
   images: {
@@ -21,6 +19,16 @@ const nextConfig: NextConfig = {
       'ticketmate.site',
       'ticketmate-storage.s3.ap-northeast-2.amazonaws.com',
     ],
+  },
+  async rewrites() {
+    return [
+      {
+        // 프론트에서 /api로 시작하는 요청을
+        source: '/api/:path*',
+        // 실제 API 서버로 프록시
+        destination: 'https://api.ticketmate.site/api/:path*',
+      },
+    ];
   },
 };
 

--- a/src/app/concert/[id]/_shared/services/bottom-sheet/api.ts
+++ b/src/app/concert/[id]/_shared/services/bottom-sheet/api.ts
@@ -10,6 +10,9 @@ const BASE_URL = '/application-form/duplicate';
 const checkDuplicateForm = async (request: CheckDuplicateFormRequest) => {
   const data = await instance(`${BASE_URL}`, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify(request),
   });
 

--- a/src/app/concert/form/[id]/_shared/services/api.ts
+++ b/src/app/concert/form/[id]/_shared/services/api.ts
@@ -8,6 +8,10 @@ import instance from '@/shared/services/instance';
 
 const BASE_URL = '/application-form';
 
+/**
+ * @description 신청서 작성
+ */
+
 const createConcertForm = async (request: CreateConcertFormRequest) => {
   const data = await instance(`${BASE_URL}`, {
     method: 'POST',
@@ -17,7 +21,7 @@ const createConcertForm = async (request: CreateConcertFormRequest) => {
     body: JSON.stringify(request),
   });
 
-  return data; // 이미 instance 인터셉터에서 JSON 파싱된 데이터 반환한다고 가정
+  return data;
 };
 
 /**

--- a/src/app/concert/form/[id]/_shared/services/api.ts
+++ b/src/app/concert/form/[id]/_shared/services/api.ts
@@ -8,16 +8,16 @@ import instance from '@/shared/services/instance';
 
 const BASE_URL = '/application-form';
 
-/**
- * @description 신청서 작성
- */
 const createConcertForm = async (request: CreateConcertFormRequest) => {
   const data = await instance(`${BASE_URL}`, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify(request),
   });
 
-  return data;
+  return data; // 이미 instance 인터셉터에서 JSON 파싱된 데이터 반환한다고 가정
 };
 
 /**
@@ -28,6 +28,9 @@ const patchConcertForm = async (request: PatchConcertFormRequest) => {
 
   const data = await instance(`${BASE_URL}/${applicationFormId}/edit`, {
     method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify(applicationFormEditRequest),
   });
 

--- a/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
+++ b/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
@@ -29,8 +29,8 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
     submittedDate,
     applicationFormStatus,
   } = formItem;
-  const { mutate: approveForm } = usePutFormApprove();
-  const { mutate: rejectForm } = usePutFormReject();
+  const { mutateAsync: approveFormAsync } = usePutFormApprove();
+  const { mutateAsync: rejectFormAsync } = usePutFormReject();
 
   const { open, closeTop } = useModal();
 
@@ -43,7 +43,7 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
           message={`의뢰인 닉네임의 요청을 수락할 시 의뢰인과 매칭이 성사되어 채팅이 가능해집니다`}
           confirmbtn={`수락`}
           onConfirm={async () => {
-            await approveForm(applicationFormId);
+            await approveFormAsync(applicationFormId);
             closeTop();
           }}
           onCancel={() => {
@@ -54,7 +54,7 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
     });
   };
 
-  const handleOpenRejectModal = (applicationFormId: string) => {
+  const handleOpenRejectModal = () => {
     open({
       id: MODAL_ID.REJECTED_MODAL,
       content: (
@@ -62,7 +62,7 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
           title="요청을 거절하시겠습니까?"
           description={`의뢰인 닉네임의 요청을 거절할 시 해당 신청내역이 삭제되고 복구할 수 없습니다.\n`}
           onConfirm={async ({ applicationFormRejectedType, otherMemo }) => {
-            await rejectForm({
+            await rejectFormAsync({
               applicationFormId,
               applicationFormRejectedType,
               otherMemo,
@@ -107,11 +107,7 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
       <div className={styles.footer_container}>
         <button className={styles.link}>자세히 보기</button>
         <div className={styles.footer_button}>
-          <Button
-            size="large"
-            variant="border"
-            onClick={() => handleOpenRejectModal(applicationFormId)}
-          >
+          <Button size="large" variant="border" onClick={handleOpenRejectModal}>
             거절
           </Button>
           <Button size="large" variant="fill" onClick={handleOpenAcceptModal}>

--- a/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
+++ b/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
@@ -43,7 +43,7 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
           message={`의뢰인 닉네임의 요청을 수락할 시 의뢰인과 매칭이 성사되어 채팅이 가능해집니다`}
           confirmbtn={`수락`}
           onConfirm={async () => {
-            await approveForm({ applicationFormId });
+            await approveForm(applicationFormId);
             closeTop();
           }}
           onCancel={() => {
@@ -54,15 +54,19 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
     });
   };
 
-  const handleOpenRejectModal = () => {
+  const handleOpenRejectModal = (applicationFormId: string) => {
     open({
       id: MODAL_ID.REJECTED_MODAL,
       content: (
         <RejectedModal
           title="요청을 거절하시겠습니까?"
           description={`의뢰인 닉네임의 요청을 거절할 시 해당 신청내역이 삭제되고 복구할 수 없습니다.\n`}
-          onConfirm={async () => {
-            await rejectForm({ applicationFormId });
+          onConfirm={async ({ applicationFormRejectedType, otherMemo }) => {
+            await rejectForm({
+              applicationFormId,
+              applicationFormRejectedType,
+              otherMemo,
+            });
             closeTop();
           }}
           onCancel={() => {
@@ -72,6 +76,7 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
       ),
     });
   };
+
   return (
     <div className={styles.container}>
       <Link className={styles.upper_container} href={`concert/form/}`}>
@@ -102,7 +107,11 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
       <div className={styles.footer_container}>
         <button className={styles.link}>자세히 보기</button>
         <div className={styles.footer_button}>
-          <Button size="large" variant="border" onClick={handleOpenRejectModal}>
+          <Button
+            size="large"
+            variant="border"
+            onClick={() => handleOpenRejectModal(applicationFormId)}
+          >
             거절
           </Button>
           <Button size="large" variant="fill" onClick={handleOpenAcceptModal}>

--- a/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
+++ b/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
@@ -11,7 +11,6 @@ import {
 import Button from '@/shared/components/button/functional-button/functional-button';
 import { MODAL_ID } from '@/shared/components/modal/modal-constants';
 import { useModal } from '@/shared/components/modal/use-modal';
-import { customToast } from '@/shared/components/toast/custom-toast/custom-toast';
 import { Form } from '@/shared/types';
 import { formatDate } from '@/shared/utils/dates';
 
@@ -46,9 +45,6 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
           onConfirm={async () => {
             await approveForm(applicationFormId);
             closeTop();
-            customToast({
-              description: `수락요청이 완료되었습니다.`,
-            });
           }}
           onCancel={() => {
             closeTop();

--- a/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
+++ b/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
@@ -11,6 +11,7 @@ import {
 import Button from '@/shared/components/button/functional-button/functional-button';
 import { MODAL_ID } from '@/shared/components/modal/modal-constants';
 import { useModal } from '@/shared/components/modal/use-modal';
+import { customToast } from '@/shared/components/toast/custom-toast/custom-toast';
 import { Form } from '@/shared/types';
 import { formatDate } from '@/shared/utils/dates';
 
@@ -45,6 +46,9 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
           onConfirm={async () => {
             await approveForm(applicationFormId);
             closeTop();
+            customToast({
+              description: `수락요청이 완료되었습니다.`,
+            });
           }}
           onCancel={() => {
             closeTop();

--- a/src/app/history/_shared/components/client-form-card/client-form-card.tsx
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.tsx
@@ -1,4 +1,6 @@
 'use client';
+import { useState } from 'react';
+
 import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -36,9 +38,13 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
     applicationFormStatus,
     ticketOpenType,
   } = formItem;
+  const [isReasonModalOpen, setIsReasonModalOpen] = useState(false);
 
   const { mutate: cancelForm } = usePutFormCancel();
-  const { data: rejectReason } = useGetRejectedReason(applicationFormId);
+  const { data: rejectReason } = useGetRejectedReason(
+    applicationFormId,
+    isReasonModalOpen,
+  );
   const queryClient = useQueryClient();
   const { open, closeTop } = useModal();
 
@@ -83,6 +89,7 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
   };
 
   const handleOpenReasonModal = () => {
+    setIsReasonModalOpen(true);
     open({
       id: MODAL_ID.REASON_MODAL,
       content: (
@@ -92,12 +99,14 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
           reason={rejectLabel}
           onConfirm={async () => {
             await new Promise((resolve) => setTimeout(resolve, 1000));
+            setIsReasonModalOpen(false);
             closeTop();
           }}
         />
       ),
     });
   };
+
   return (
     <div className={styles.container}>
       <Link

--- a/src/app/history/_shared/components/client-form-card/client-form-card.tsx
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.tsx
@@ -38,7 +38,7 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
   } = formItem;
 
   const { mutate: cancelForm } = usePutFormCancel();
-  const { data: rejectReason } = useGetRejectedReason({ applicationFormId });
+  const { data: rejectReason } = useGetRejectedReason(applicationFormId);
   const queryClient = useQueryClient();
   const { open, closeTop } = useModal();
 
@@ -64,17 +64,14 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
           message={`취소 시 신청했던 내역은 \n과거신청내역에서 확인가능합니다.`}
           confirmbtn={`취소하기`}
           onConfirm={async () => {
-            await cancelForm(
-              { applicationFormId },
-              {
-                onSuccess: () => {
-                  // 캐시를 무효화하고 리스트를 다시 요청해 최신 상태로 반영
-                  queryClient.invalidateQueries({
-                    queryKey: queryKey.getConcertList(),
-                  });
-                },
+            await cancelForm(applicationFormId, {
+              onSuccess: () => {
+                // 캐시를 무효화하고 리스트를 다시 요청해 최신 상태로 반영
+                queryClient.invalidateQueries({
+                  queryKey: queryKey.getConcertList(),
+                });
               },
-            );
+            });
             closeTop();
           }}
           onCancel={() => {

--- a/src/app/history/_shared/components/client-form-card/client-form-card.tsx
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.tsx
@@ -5,11 +5,11 @@ import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
 
-import queryKey from '@/app/_shared/services/query-key';
 import CancelModal from '@/app/history/_shared/components/modal/common-modal';
 import ReasonModal from '@/app/history/_shared/components/modal/reason-modal/reason-modal';
 import { usePutFormCancel } from '@/app/history/_shared/services/mutation';
 import { useGetRejectedReason } from '@/app/history/_shared/services/query';
+import queryKey from '@/app/history/_shared/services/query-key';
 import { MODAL_ID } from '@/shared/components/modal/modal-constants';
 import { useModal } from '@/shared/components/modal/use-modal';
 import {
@@ -40,7 +40,7 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
   } = formItem;
   const [isReasonModalOpen, setIsReasonModalOpen] = useState(false);
 
-  const { mutate: cancelForm } = usePutFormCancel();
+  const { mutateAsync: cancelFormAsync } = usePutFormCancel();
   const { data: rejectReason } = useGetRejectedReason(
     applicationFormId,
     isReasonModalOpen,
@@ -70,15 +70,15 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
           message={`취소 시 신청했던 내역은 \n과거신청내역에서 확인가능합니다.`}
           confirmbtn={`취소하기`}
           onConfirm={async () => {
-            await cancelForm(applicationFormId, {
-              onSuccess: () => {
-                // 캐시를 무효화하고 리스트를 다시 요청해 최신 상태로 반영
-                queryClient.invalidateQueries({
-                  queryKey: queryKey.getConcertList(),
-                });
-              },
-            });
-            closeTop();
+            try {
+              await cancelFormAsync(applicationFormId);
+              queryClient.invalidateQueries({
+                queryKey: queryKey.getFormList(),
+              });
+              closeTop();
+            } catch {
+              // 에러 토스트는 훅에서 처리 중
+            }
           }}
           onCancel={() => {
             closeTop();

--- a/src/app/history/_shared/components/client-form-card/client-form-card.tsx
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.tsx
@@ -98,7 +98,8 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
           description={`작성한 신청양식을 통해 동일한 대리인에게 다시 티켓팅을 의뢰할 수 있습니다.\n`}
           reason={rejectLabel}
           onConfirm={async () => {
-            await new Promise((resolve) => setTimeout(resolve, 1000));
+            //없이 테스트 한번 진행해보고 깜빡이는 현상 없으면 제거 있으면 추가하는 방향으로
+            // await new Promise((resolve) => setTimeout(resolve, 1000));
             setIsReasonModalOpen(false);
             closeTop();
           }}

--- a/src/app/history/_shared/components/client-form-card/client-form-card.tsx
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.tsx
@@ -1,5 +1,4 @@
 'use client';
-import { useState } from 'react';
 
 import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
@@ -38,13 +37,9 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
     applicationFormStatus,
     ticketOpenType,
   } = formItem;
-  const [isReasonModalOpen, setIsReasonModalOpen] = useState(false);
 
   const { mutateAsync: cancelFormAsync } = usePutFormCancel();
-  const { data: rejectReason } = useGetRejectedReason(
-    applicationFormId,
-    isReasonModalOpen,
-  );
+  const { data: rejectReason } = useGetRejectedReason(applicationFormId);
   const queryClient = useQueryClient();
   const { open, closeTop } = useModal();
 
@@ -89,7 +84,6 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
   };
 
   const handleOpenReasonModal = () => {
-    setIsReasonModalOpen(true);
     open({
       id: MODAL_ID.REASON_MODAL,
       content: (
@@ -97,10 +91,7 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
           title="대리인 닉네임님의 거절 사유"
           description={`작성한 신청양식을 통해 동일한 대리인에게 다시 티켓팅을 의뢰할 수 있습니다.\n`}
           reason={rejectLabel}
-          onConfirm={async () => {
-            //없이 테스트 한번 진행해보고 깜빡이는 현상 없으면 제거 있으면 추가하는 방향으로
-            // await new Promise((resolve) => setTimeout(resolve, 1000));
-            setIsReasonModalOpen(false);
+          onConfirm={() => {
             closeTop();
           }}
         />

--- a/src/app/history/_shared/components/history-list/history-list.tsx
+++ b/src/app/history/_shared/components/history-list/history-list.tsx
@@ -53,7 +53,7 @@ const HistoryList = ({ tab }: HistoryListProps) => {
         </span>
         {filteredList.map((formItem) => (
           <div key={formItem.applicationFormId}>
-            {memberType === 'client' ? (
+            {memberType === 'CLIENT' ? (
               <ClientFormCard formItem={formItem} />
             ) : (
               <AgentFormCard formItem={formItem} />

--- a/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.module.scss
+++ b/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.module.scss
@@ -4,3 +4,14 @@
   @include text-sm;
   color: var(--textColor-main);
 }
+
+.error_container {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  .error_message {
+    @include text-xs;
+    color: var(--brandColor-main);
+  }
+}

--- a/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.module.scss
+++ b/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.module.scss
@@ -4,14 +4,3 @@
   @include text-sm;
   color: var(--textColor-main);
 }
-
-.error_container {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-
-  .error_message {
-    @include text-xs;
-    color: var(--brandColor-main);
-  }
-}

--- a/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.tsx
+++ b/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.tsx
@@ -5,6 +5,7 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import styles from '@/app/history/_shared/components/modal/rejected-modal/rejected-modal.module.scss';
+import { AlertCircleIcon } from '@/assets/icons';
 import Button from '@/shared/components/button/functional-button/functional-button';
 import CustomModal from '@/shared/components/modal/custom-modal';
 import RadioGroup from '@/shared/components/radio/radio';
@@ -32,6 +33,7 @@ const RejectedModal = ({
   const [customText, setCustomText] = useState('');
   const [error, setError] = useState('');
 
+  // 제출 시 조건 확인하는 핸들러
   const handleConfirm = async () => {
     if (!selected) {
       setError('거절 사유를 선택하거나 입력해주세요.');
@@ -56,10 +58,12 @@ const RejectedModal = ({
     router.push(`/history`);
   };
 
+  // 취소하는 핸들러
   const handleCancel = () => {
     if (onCancel) onCancel();
   };
 
+  // 라디오 버튼 변경할 때 초기화하는 핸들러
   const handleRadioChange = (value: string) => {
     setSelected(value);
     setError('');
@@ -67,7 +71,7 @@ const RejectedModal = ({
       setCustomText('');
     }
   };
-
+  // '기타' 사유 작성 시 조건 확인하는 핸들러
   const handleCustomTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setCustomText(e.target.value);
     if (e.target.value.length < 5) {
@@ -120,7 +124,16 @@ const RejectedModal = ({
               maxLength={50}
             />
           )}
-          {error && <p className={styles.error}>{error}</p>}
+          {error && (
+            <div className={styles.error_container}>
+              <AlertCircleIcon
+                width={16}
+                height={16}
+                fill="var(--brandColor-main)"
+              />
+              <span className={styles.error_message}>{error}</span>
+            </div>
+          )}
         </CustomModal.Action>
       </CustomModal.Description>
       <CustomModal.Action>

--- a/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.tsx
+++ b/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.tsx
@@ -39,7 +39,7 @@ const RejectedModal = ({
     }
     if (
       selected === 'OTHER' &&
-      (customText.length < 5 || customText.length > 50)
+      (customText.trim().length < 5 || customText.trim().length > 50)
     ) {
       setError('기타 사유는 5자 이상 50자 이내여야 합니다.');
       return;
@@ -48,7 +48,7 @@ const RejectedModal = ({
     const applicationFormRejectedType = selected as
       | ApplicationRejectedType
       | 'OTHER';
-    const otherMemo = selected === 'OTHER' ? customText : '';
+    const otherMemo = selected === 'OTHER' ? customText.trim() : '';
 
     if (onConfirm) {
       await onConfirm({ applicationFormRejectedType, otherMemo });

--- a/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.tsx
+++ b/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.tsx
@@ -8,11 +8,16 @@ import styles from '@/app/history/_shared/components/modal/rejected-modal/reject
 import Button from '@/shared/components/button/functional-button/functional-button';
 import CustomModal from '@/shared/components/modal/custom-modal';
 import RadioGroup from '@/shared/components/radio/radio';
+import { APPLICATION_REJECTED_LABEL_MAP } from '@/shared/constants/type-mapping';
+import { ApplicationRejectedType } from '@/shared/types';
 
 interface RejectedModalProps {
   title: string;
   description?: string;
-  onConfirm?: () => Promise<void> | void;
+  onConfirm?: (params: {
+    applicationFormRejectedType: ApplicationRejectedType | 'OTHER';
+    otherMemo: string;
+  }) => Promise<void> | void;
   onCancel?: () => Promise<void> | void;
 }
 
@@ -22,12 +27,32 @@ const RejectedModal = ({
   onConfirm,
   onCancel,
 }: RejectedModalProps) => {
-  const router = useRouter(); // useRouter 훅을 사용하여 라우팅 처리
+  const router = useRouter();
   const [selected, setSelected] = useState<string | null>(null);
+  const [customText, setCustomText] = useState('');
   const [error, setError] = useState('');
 
   const handleConfirm = async () => {
-    if (onConfirm) await onConfirm();
+    if (!selected) {
+      setError('거절 사유를 선택하거나 입력해주세요.');
+      return;
+    }
+    if (
+      selected === 'OTHER' &&
+      (customText.length < 5 || customText.length > 50)
+    ) {
+      setError('기타 사유는 5자 이상 50자 이내여야 합니다.');
+      return;
+    }
+
+    const applicationFormRejectedType = selected as
+      | ApplicationRejectedType
+      | 'OTHER';
+    const otherMemo = selected === 'OTHER' ? customText : '';
+
+    if (onConfirm) {
+      await onConfirm({ applicationFormRejectedType, otherMemo });
+    }
     router.push(`/history`);
   };
 
@@ -37,15 +62,18 @@ const RejectedModal = ({
 
   const handleRadioChange = (value: string) => {
     setSelected(value);
+    setError('');
+    if (value !== 'OTHER') {
+      setCustomText('');
+    }
+  };
 
-    if (!value.startsWith('option')) {
-      if (value.length < 5) {
-        setError('최소 5자 이상 입력해야 합니다.');
-      } else if (value.length > 50) {
-        setError('최대 50자 이내여야 합니다.');
-      } else {
-        setError('');
-      }
+  const handleCustomTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setCustomText(e.target.value);
+    if (e.target.value.length < 5) {
+      setError('최소 5자 이상 입력해야 합니다.');
+    } else if (e.target.value.length > 50) {
+      setError('최대 50자 이내여야 합니다.');
     } else {
       setError('');
     }
@@ -59,18 +87,40 @@ const RejectedModal = ({
         <span className={styles.reason}>거절 사유를 선택해주세요.</span>
         <CustomModal.Action>
           <RadioGroup
-            name="example"
+            name="rejectReason"
             value={selected}
             onChange={handleRadioChange}
           >
             <RadioGroup.Radio
-              value="option1"
-              label="수고비가 시세와 맞지않음"
+              value="FEE_NOT_MATCHING_MARKET_PRICE"
+              label={
+                APPLICATION_REJECTED_LABEL_MAP.FEE_NOT_MATCHING_MARKET_PRICE
+              }
             />
-            <RadioGroup.Radio value="option2" label="예약이 마감됨" />
-            <RadioGroup.Radio value="option3" label="티켓팅 일정이 안됨" />
-            <RadioGroup.RadioInput placeholder="기타" error={error} />
+            <RadioGroup.Radio
+              value="RESERVATION_CLOSED"
+              label={APPLICATION_REJECTED_LABEL_MAP.RESERVATION_CLOSED}
+            />
+            <RadioGroup.Radio
+              value="SCHEDULE_UNAVAILABLE"
+              label={APPLICATION_REJECTED_LABEL_MAP.SCHEDULE_UNAVAILABLE}
+            />
+            <RadioGroup.Radio
+              value="OTHER"
+              label={APPLICATION_REJECTED_LABEL_MAP.OTHER}
+            />
           </RadioGroup>
+          {selected === 'OTHER' && (
+            <input
+              type="text"
+              placeholder="기타 사유를 입력하세요"
+              value={customText}
+              onChange={handleCustomTextChange}
+              className={styles.customInput}
+              maxLength={50}
+            />
+          )}
+          {error && <p className={styles.error}>{error}</p>}
         </CustomModal.Action>
       </CustomModal.Description>
       <CustomModal.Action>

--- a/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.tsx
+++ b/src/app/history/_shared/components/modal/rejected-modal/rejected-modal.tsx
@@ -5,7 +5,6 @@ import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import styles from '@/app/history/_shared/components/modal/rejected-modal/rejected-modal.module.scss';
-import { AlertCircleIcon } from '@/assets/icons';
 import Button from '@/shared/components/button/functional-button/functional-button';
 import CustomModal from '@/shared/components/modal/custom-modal';
 import RadioGroup from '@/shared/components/radio/radio';
@@ -71,17 +70,18 @@ const RejectedModal = ({
       setCustomText('');
     }
   };
-  // '기타' 사유 작성 시 조건 확인하는 핸들러
-  const handleCustomTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setCustomText(e.target.value);
-    if (e.target.value.length < 5) {
-      setError('최소 5자 이상 입력해야 합니다.');
-    } else if (e.target.value.length > 50) {
-      setError('최대 50자 이내여야 합니다.');
-    } else {
-      setError('');
-    }
-  };
+
+  // 추후 추가할 얘정
+  // const handleCustomTextChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  //   setCustomText(e.target.value);
+  //   if (e.target.value.length < 5) {
+  //     setError('최소 5자 이상 입력해야 합니다.');
+  //   } else if (e.target.value.length > 50) {
+  //     setError('최대 50자 이내여야 합니다.');
+  //   } else {
+  //     setError('');
+  //   }
+  // };
 
   return (
     <CustomModal>
@@ -109,31 +109,8 @@ const RejectedModal = ({
               value="SCHEDULE_UNAVAILABLE"
               label={APPLICATION_REJECTED_LABEL_MAP.SCHEDULE_UNAVAILABLE}
             />
-            <RadioGroup.Radio
-              value="OTHER"
-              label={APPLICATION_REJECTED_LABEL_MAP.OTHER}
-            />
+            <RadioGroup.RadioInput placeholder="기타" error={error} />
           </RadioGroup>
-          {selected === 'OTHER' && (
-            <input
-              type="text"
-              placeholder="기타 사유를 입력하세요"
-              value={customText}
-              onChange={handleCustomTextChange}
-              className={styles.customInput}
-              maxLength={50}
-            />
-          )}
-          {error && (
-            <div className={styles.error_container}>
-              <AlertCircleIcon
-                width={16}
-                height={16}
-                fill="var(--brandColor-main)"
-              />
-              <span className={styles.error_message}>{error}</span>
-            </div>
-          )}
         </CustomModal.Action>
       </CustomModal.Description>
       <CustomModal.Action>

--- a/src/app/history/_shared/services/api.ts
+++ b/src/app/history/_shared/services/api.ts
@@ -26,13 +26,10 @@ const getFormList = async (request?: GetFormListRequest) => {
 /**
  * @description 공연 신청폼 수락
  */
-const patchFormApprove = async (request: PutFormRequest) => {
-  const { applicationFormId } = request;
-
+const patchFormApprove = async (applicationFormId: string) => {
   const data = await instance(`${BASE_URL}/${applicationFormId}/accept`, {
     method: 'PATCH',
   });
-
   return data;
 };
 
@@ -40,10 +37,14 @@ const patchFormApprove = async (request: PutFormRequest) => {
  * @description 공연 신청폼 거절
  */
 const patchFormReject = async (request: PutFormRequest) => {
-  const { applicationFormId } = request;
+  const { applicationFormId, applicationFormRejectedType, otherMemo } = request;
 
   const data = await instance(`${BASE_URL}/${applicationFormId}/reject`, {
     method: 'PATCH',
+    body: JSON.stringify({
+      applicationFormRejectedType,
+      otherMemo,
+    }),
   });
 
   return data;
@@ -52,9 +53,7 @@ const patchFormReject = async (request: PutFormRequest) => {
 /**
  * @description 공연 신청폼 신청취소(의뢰인)
  */
-const patchFormCancel = async (request: PutFormRequest) => {
-  const { applicationFormId } = request;
-
+const patchFormCancel = async (applicationFormId: string) => {
   const data = await instance(`${BASE_URL}/${applicationFormId}/cancel`, {
     method: 'PATCH',
   });
@@ -65,9 +64,7 @@ const patchFormCancel = async (request: PutFormRequest) => {
 /**
  * @description 신청서 거절 사유 조회
  */
-const getRejectionReason = async (request: PutFormRequest) => {
-  const { applicationFormId } = request;
-
+const getRejectionReason = async (applicationFormId: string) => {
   const data = await instance<GetRejectionReasonResponse>(
     `${BASE_URL}/${applicationFormId}/rejection-reason`,
     {

--- a/src/app/history/_shared/services/api.ts
+++ b/src/app/history/_shared/services/api.ts
@@ -41,6 +41,9 @@ const patchFormReject = async (request: PutFormRequest) => {
 
   const data = await instance(`${BASE_URL}/${applicationFormId}/reject`, {
     method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
     body: JSON.stringify({
       applicationFormRejectedType,
       otherMemo,

--- a/src/app/history/_shared/services/mutation.ts
+++ b/src/app/history/_shared/services/mutation.ts
@@ -5,10 +5,10 @@ import { PutFormRequest } from './type';
 
 export const usePutFormApprove = () => {
   return useMutation({
-    mutationFn: (request: PutFormRequest) => patchFormApprove(request),
+    mutationFn: (applicationFormId: string) =>
+      patchFormApprove(applicationFormId),
   });
 };
-
 export const usePutFormReject = () => {
   return useMutation({
     mutationFn: (request: PutFormRequest) => patchFormReject(request),
@@ -17,6 +17,7 @@ export const usePutFormReject = () => {
 
 export const usePutFormCancel = () => {
   return useMutation({
-    mutationFn: (request: PutFormRequest) => patchFormCancel(request),
+    mutationFn: (applicationFormId: string) =>
+      patchFormCancel(applicationFormId),
   });
 };

--- a/src/app/history/_shared/services/mutation.ts
+++ b/src/app/history/_shared/services/mutation.ts
@@ -1,5 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 
+import { customToast } from '@/shared/components/toast/custom-toast/custom-toast';
+
 import { patchFormApprove, patchFormCancel, patchFormReject } from './api';
 import { PutFormRequest } from './type';
 
@@ -7,11 +9,31 @@ export const usePutFormApprove = () => {
   return useMutation({
     mutationFn: (applicationFormId: string) =>
       patchFormApprove(applicationFormId),
+    onSuccess: () => {
+      customToast({
+        description: '요청수락이 완료되었습니다.',
+      });
+    },
+    onError: () => {
+      customToast({
+        description: '요청수락 중 오류가 발생했습니다.',
+      });
+    },
   });
 };
 export const usePutFormReject = () => {
   return useMutation({
     mutationFn: (request: PutFormRequest) => patchFormReject(request),
+    onSuccess: () => {
+      customToast({
+        description: '요청거절이 완료되었습니다.',
+      });
+    },
+    onError: () => {
+      customToast({
+        description: '요청거절 중 오류가 발생했습니다.',
+      });
+    },
   });
 };
 
@@ -19,5 +41,15 @@ export const usePutFormCancel = () => {
   return useMutation({
     mutationFn: (applicationFormId: string) =>
       patchFormCancel(applicationFormId),
+    onSuccess: () => {
+      customToast({
+        description: '취소가 완료되었습니다.',
+      });
+    },
+    onError: () => {
+      customToast({
+        description: '취소 중 오류가 발생했습니다.',
+      });
+    },
   });
 };

--- a/src/app/history/_shared/services/query-key.ts
+++ b/src/app/history/_shared/services/query-key.ts
@@ -1,10 +1,10 @@
-import { GetFormListRequest, PutFormRequest } from './type';
+import { GetFormListRequest } from './type';
 
 const queryKey = {
   getFormList: (request?: GetFormListRequest) => ['getFormList', request],
-  getRejectionReason: (request?: PutFormRequest) => [
+  getRejectionReason: (applicationFormId: string) => [
     'getRejectReason',
-    request,
+    applicationFormId,
   ],
 };
 

--- a/src/app/history/_shared/services/query.ts
+++ b/src/app/history/_shared/services/query.ts
@@ -13,10 +13,11 @@ const useGetFormList = (request?: GetFormListRequest) => {
   return { data, isLoading, isError };
 };
 
-const useGetRejectedReason = (applicationFormId: string) => {
+const useGetRejectedReason = (applicationFormId: string, enabled: boolean) => {
   const { data, isLoading, isError } = useQuery({
     queryKey: queryKey.getRejectionReason(applicationFormId),
     queryFn: () => getRejectionReason(applicationFormId),
+    enabled,
   });
 
   return { data, isLoading, isError };

--- a/src/app/history/_shared/services/query.ts
+++ b/src/app/history/_shared/services/query.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 
 import { getFormList, getRejectionReason } from './api';
 import queryKey from './query-key';
-import { GetFormListRequest, PutFormRequest } from './type';
+import { GetFormListRequest } from './type';
 
 const useGetFormList = (request?: GetFormListRequest) => {
   const { data, isLoading, isError } = useQuery({
@@ -13,10 +13,10 @@ const useGetFormList = (request?: GetFormListRequest) => {
   return { data, isLoading, isError };
 };
 
-const useGetRejectedReason = (request: PutFormRequest) => {
+const useGetRejectedReason = (applicationFormId: string) => {
   const { data, isLoading, isError } = useQuery({
-    queryKey: queryKey.getRejectionReason(request),
-    queryFn: () => getRejectionReason(request),
+    queryKey: queryKey.getRejectionReason(applicationFormId),
+    queryFn: () => getRejectionReason(applicationFormId),
   });
 
   return { data, isLoading, isError };

--- a/src/app/history/_shared/services/query.ts
+++ b/src/app/history/_shared/services/query.ts
@@ -13,11 +13,10 @@ const useGetFormList = (request?: GetFormListRequest) => {
   return { data, isLoading, isError };
 };
 
-const useGetRejectedReason = (applicationFormId: string, enabled: boolean) => {
+const useGetRejectedReason = (applicationFormId: string) => {
   const { data, isLoading, isError } = useQuery({
     queryKey: queryKey.getRejectionReason(applicationFormId),
     queryFn: () => getRejectionReason(applicationFormId),
-    enabled,
   });
 
   return { data, isLoading, isError };

--- a/src/app/history/_shared/services/type.ts
+++ b/src/app/history/_shared/services/type.ts
@@ -20,6 +20,8 @@ type GetFormListResponse = Pagination<Form>;
 
 interface PutFormRequest {
   applicationFormId: string;
+  applicationFormRejectedType: ApplicationRejectedType;
+  otherMemo: string;
 }
 
 interface GetRejectionReasonResponse {

--- a/src/shared/components/radio/radio.tsx
+++ b/src/shared/components/radio/radio.tsx
@@ -4,6 +4,8 @@ import React, { ReactNode, useContext, ChangeEvent } from 'react';
 
 import classNames from 'classnames/bind';
 
+import { AlertCircleIcon } from '@/assets/icons';
+
 import styles from './radio.module.scss';
 
 const cn = classNames.bind(styles);
@@ -55,11 +57,13 @@ const Radio = ({ value, label, disabled = false }: RadioProps) => {
 interface RadioInputProps {
   placeholder?: string;
   disabled?: boolean;
+  error?: string;
 }
 
 const RadioInput = ({
   placeholder = '직접 입력',
   disabled = false,
+  error = '',
 }: RadioInputProps) => {
   const context = useContext(RadioGroupContext);
   if (!context)
@@ -102,6 +106,16 @@ const RadioInput = ({
           maxLength={50}
         />
       </label>
+      {isChecked && error && (
+        <div className={cn('error_container')}>
+          <AlertCircleIcon
+            width={16}
+            height={16}
+            fill="var(--brandColor-main)"
+          />
+          <span className={cn('error_message')}>{error}</span>
+        </div>
+      )}
     </>
   );
 };

--- a/src/shared/components/radio/radio.tsx
+++ b/src/shared/components/radio/radio.tsx
@@ -4,8 +4,6 @@ import React, { ReactNode, useContext, ChangeEvent } from 'react';
 
 import classNames from 'classnames/bind';
 
-import { AlertCircleIcon } from '@/assets/icons';
-
 import styles from './radio.module.scss';
 
 const cn = classNames.bind(styles);
@@ -57,13 +55,11 @@ const Radio = ({ value, label, disabled = false }: RadioProps) => {
 interface RadioInputProps {
   placeholder?: string;
   disabled?: boolean;
-  error?: string;
 }
 
 const RadioInput = ({
   placeholder = '직접 입력',
   disabled = false,
-  error = '',
 }: RadioInputProps) => {
   const context = useContext(RadioGroupContext);
   if (!context)
@@ -78,8 +74,7 @@ const RadioInput = ({
     if (!disabled) onChange('');
   };
   const handleInputChange = (e: ChangeEvent<HTMLInputElement>) => {
-    if (disabled) return;
-    onChange(e.target.value);
+    if (!disabled) onChange(e.target.value);
   };
 
   return (
@@ -107,16 +102,6 @@ const RadioInput = ({
           maxLength={50}
         />
       </label>
-      {isChecked && error && (
-        <div className={cn('error_container')}>
-          <AlertCircleIcon
-            width={16}
-            height={16}
-            fill="var(--brandColor-main)"
-          />
-          <span className={cn('error_message')}>{error}</span>
-        </div>
-      )}
     </>
   );
 };


### PR DESCRIPTION
## 💻구현 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- 파라미터만 넘기는 값들은 request에서 객체로 변경
- 거절조회 api에 request api 추가
- #105 
<br><br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br><br>

## #️⃣연관된 이슈

> 아래에 {이슈번호}를 작성해주세요
> <br>
> close #105

<br><br>

## ⚠️코멘트

> 리뷰어에게 남길 코멘트가 있다면 작성해주세요


중간에 pr 날리는 과정에서 잠깐 꼬여버리는 바람에 커밋이 많아졌습니다.... 커밋별로 보시기보단 파일별로 보시는걸 권장드립니다.
브랜치의 메인 내용인 거절조회api에 응답값/요청값 수정 및 api 파라미터 수정에 대한 테스트는 모두 완료하였습니다.
<br>

추가적으로 수정해야하는 기능
1. 거절 사유 선택 및 작성 시 요청값 전달되는 부분 수정(radioInput을 일부 수정해야할 것 같아 수정하다가 멈춰습니다)
2. 의뢰인,대리인 신청내역 취소/거절/수락 과 같은 액션 후 재조회(현재 코드는 작성되어있지만, 제대로 실행되지 않고 있습니다. 이번브랜치는 조회에 요청값을 추가하는 부분이 중심이라 추후 수정할 예정입니다)


<br><br>

## ✅Check List

- [x] PR 제목 규칙
- [x] 추가/수정사항
- [x] 이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rejection modal: selectable reasons with labels, “Other” text input (5–50 chars) and validation; confirming returns users to History.
  * Success/error toasts for approve, reject, and cancel actions.

* **Bug Fixes**
  * History list membership check corrected so Client/Agent cards render properly.
  * Cancellation/rejection flows and modal lifecycles made more reliable with improved error handling.

* **Chores**
  * Added proxy rewrite to forward local /api requests to the external API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->