### PR TITLE
신청내역 api 호출 후 재조회 안되는 에러

### DIFF
--- a/src/app/concert/form/[id]/_shared/components/form-tab/form-tab-manager.tsx
+++ b/src/app/concert/form/[id]/_shared/components/form-tab/form-tab-manager.tsx
@@ -56,7 +56,7 @@ export default function FormTabManager({
       status === 'REJECTED'
     )
       return 'readApp';
-    // ACCEPTED 혹은 그 외의 상태는 undefined로 둬서 아무 동작 안 하도록
+    // APPROVED 혹은 그 외의 상태는 undefined로 둬서 아무 동작 안 하도록
     return undefined;
   });
   //input과 readapp을 구분해서 제출을 하기 위해 state로 관리

--- a/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
+++ b/src/app/history/_shared/components/agent-form-card/agent-form-card.tsx
@@ -5,8 +5,8 @@ import Link from 'next/link';
 import AcceptModal from '@/app/history/_shared/components/modal/common-modal';
 import RejectedModal from '@/app/history/_shared/components/modal/rejected-modal/rejected-modal';
 import {
-  usePutFormApprove,
-  usePutFormReject,
+  usePatchFormApprove,
+  usePatchFormReject,
 } from '@/app/history/_shared/services/mutation';
 import Button from '@/shared/components/button/functional-button/functional-button';
 import { MODAL_ID } from '@/shared/components/modal/modal-constants';
@@ -29,8 +29,8 @@ const AgentFormCard = ({ formItem }: FormCardProps) => {
     submittedDate,
     applicationFormStatus,
   } = formItem;
-  const { mutateAsync: approveFormAsync } = usePutFormApprove();
-  const { mutateAsync: rejectFormAsync } = usePutFormReject();
+  const { mutateAsync: approveFormAsync } = usePatchFormApprove();
+  const { mutateAsync: rejectFormAsync } = usePatchFormReject();
 
   const { open, closeTop } = useModal();
 

--- a/src/app/history/_shared/components/client-form-card/client-form-card.module.scss
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.module.scss
@@ -69,7 +69,7 @@
       @include title-sm;
       color: var(--textColor-main);
     }
-    .accepted {
+    .approved {
       @include title-sm;
       color: var(--subColor-main);
     }

--- a/src/app/history/_shared/components/client-form-card/client-form-card.tsx
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 
 import CancelModal from '@/app/history/_shared/components/modal/common-modal';
 import ReasonModal from '@/app/history/_shared/components/modal/reason-modal/reason-modal';
-import { usePutFormCancel } from '@/app/history/_shared/services/mutation';
+import { usePatchFormCancel } from '@/app/history/_shared/services/mutation';
 import { useGetRejectedReason } from '@/app/history/_shared/services/query';
 import { MODAL_ID } from '@/shared/components/modal/modal-constants';
 import { useModal } from '@/shared/components/modal/use-modal';
@@ -36,7 +36,7 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
     ticketOpenType,
   } = formItem;
 
-  const { mutateAsync: cancelFormAsync } = usePutFormCancel();
+  const { mutateAsync: cancelFormAsync } = usePatchFormCancel();
   const { data: rejectReason } = useGetRejectedReason(applicationFormId);
   const { open, closeTop } = useModal();
   const { applicationFormRejectedType, otherMemo } = rejectReason ?? {};

--- a/src/app/history/_shared/components/client-form-card/client-form-card.tsx
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.tsx
@@ -123,12 +123,12 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
         </div>
       </Link>
       <div className={styles.footer_container}>
-        {statusKey === 'ACCEPTED' ? (
+        {statusKey === 'APPROVED' ? (
           <>
             <Link className={styles.link} href="/chat">
               채팅하기
             </Link>
-            <span className={styles.accepted}>{statusLabel}</span>
+            <span className={styles.approved}>{statusLabel}</span>
           </>
         ) : statusKey === 'PENDING' ? (
           <>

--- a/src/app/history/_shared/components/client-form-card/client-form-card.tsx
+++ b/src/app/history/_shared/components/client-form-card/client-form-card.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useQueryClient } from '@tanstack/react-query';
 import Image from 'next/image';
 import Link from 'next/link';
 
@@ -8,7 +7,6 @@ import CancelModal from '@/app/history/_shared/components/modal/common-modal';
 import ReasonModal from '@/app/history/_shared/components/modal/reason-modal/reason-modal';
 import { usePutFormCancel } from '@/app/history/_shared/services/mutation';
 import { useGetRejectedReason } from '@/app/history/_shared/services/query';
-import queryKey from '@/app/history/_shared/services/query-key';
 import { MODAL_ID } from '@/shared/components/modal/modal-constants';
 import { useModal } from '@/shared/components/modal/use-modal';
 import {
@@ -40,9 +38,7 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
 
   const { mutateAsync: cancelFormAsync } = usePutFormCancel();
   const { data: rejectReason } = useGetRejectedReason(applicationFormId);
-  const queryClient = useQueryClient();
   const { open, closeTop } = useModal();
-
   const { applicationFormRejectedType, otherMemo } = rejectReason ?? {};
 
   //type별 status 이름 변환
@@ -67,9 +63,6 @@ const ClientFormCard = ({ formItem }: FormCardProps) => {
           onConfirm={async () => {
             try {
               await cancelFormAsync(applicationFormId);
-              queryClient.invalidateQueries({
-                queryKey: queryKey.getFormList(),
-              });
               closeTop();
             } catch {
               // 에러 토스트는 훅에서 처리 중

--- a/src/app/history/_shared/hooks/usePatchForm.ts
+++ b/src/app/history/_shared/hooks/usePatchForm.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import queryKey from '@/app/history/_shared/services/query-key';
+import { customToast } from '@/shared/components/toast/custom-toast/custom-toast';
+
+type MutationFn<T> = (payload: T) => Promise<unknown>;
+
+interface UsePatchFormOptions<T> {
+  mutationFn: MutationFn<T>;
+  successMessage: string;
+  errorMessage: string;
+}
+
+export const usePatchForm = <T>({
+  mutationFn,
+  successMessage,
+  errorMessage,
+}: UsePatchFormOptions<T>) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn,
+    onSuccess: () => {
+      customToast({ description: successMessage });
+      queryClient.invalidateQueries({ queryKey: queryKey.getFormList() });
+    },
+    onError: () => {
+      customToast({ description: errorMessage });
+    },
+  });
+};

--- a/src/app/history/_shared/services/api.ts
+++ b/src/app/history/_shared/services/api.ts
@@ -1,7 +1,7 @@
 import {
   GetFormListRequest,
   GetFormListResponse,
-  PutFormRequest,
+  PatchFormRequest,
   GetRejectionReasonResponse,
 } from '@/app/history/_shared/services/type';
 import instance from '@/shared/services/instance';
@@ -36,7 +36,7 @@ const patchFormApprove = async (applicationFormId: string) => {
 /**
  * @description 공연 신청폼 거절
  */
-const patchFormReject = async (request: PutFormRequest) => {
+const patchFormReject = async (request: PatchFormRequest) => {
   const { applicationFormId, applicationFormRejectedType, otherMemo } = request;
 
   const data = await instance(`${BASE_URL}/${applicationFormId}/reject`, {

--- a/src/app/history/_shared/services/mutation.ts
+++ b/src/app/history/_shared/services/mutation.ts
@@ -1,71 +1,24 @@
-import { useMutation, useQueryClient } from '@tanstack/react-query';
-
-import queryKey from '@/app/history/_shared/services/query-key';
-import { customToast } from '@/shared/components/toast/custom-toast/custom-toast';
-
 import { patchFormApprove, patchFormCancel, patchFormReject } from './api';
 import { PutFormRequest } from './type';
+import { usePatchForm } from '../hooks/usePatchForm';
 
-export const usePutFormApprove = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (applicationFormId: string) =>
-      patchFormApprove(applicationFormId),
-    onSuccess: () => {
-      customToast({
-        description: '요청수락이 완료되었습니다.',
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKey.getFormList(),
-      });
-    },
-    onError: () => {
-      customToast({
-        description: '요청수락 중 오류가 발생했습니다.',
-      });
-    },
+export const usePatchFormApprove = () =>
+  usePatchForm<string>({
+    mutationFn: (applicationFormId) => patchFormApprove(applicationFormId),
+    successMessage: '요청수락이 완료되었습니다.',
+    errorMessage: '요청수락 중 오류가 발생했습니다.',
   });
-};
-export const usePutFormReject = () => {
-  const queryClient = useQueryClient();
 
-  return useMutation({
-    mutationFn: (request: PutFormRequest) => patchFormReject(request),
-    onSuccess: () => {
-      customToast({
-        description: '요청거절이 완료되었습니다.',
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKey.getFormList(),
-      });
-    },
-    onError: () => {
-      customToast({
-        description: '요청거절 중 오류가 발생했습니다.',
-      });
-    },
+export const usePatchFormReject = () =>
+  usePatchForm<PutFormRequest>({
+    mutationFn: (request) => patchFormReject(request),
+    successMessage: '요청거절이 완료되었습니다.',
+    errorMessage: '요청거절 중 오류가 발생했습니다.',
   });
-};
 
-export const usePutFormCancel = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: (applicationFormId: string) =>
-      patchFormCancel(applicationFormId),
-    onSuccess: () => {
-      customToast({
-        description: '취소가 완료되었습니다.',
-      });
-      queryClient.invalidateQueries({
-        queryKey: queryKey.getFormList(),
-      });
-    },
-    onError: () => {
-      customToast({
-        description: '취소 중 오류가 발생했습니다.',
-      });
-    },
+export const usePatchFormCancel = () =>
+  usePatchForm<string>({
+    mutationFn: (applicationFormId) => patchFormCancel(applicationFormId),
+    successMessage: '취소가 완료되었습니다.',
+    errorMessage: '취소 중 오류가 발생했습니다.',
   });
-};

--- a/src/app/history/_shared/services/mutation.ts
+++ b/src/app/history/_shared/services/mutation.ts
@@ -1,6 +1,7 @@
+import { usePatchForm } from '@/app/history/_shared/hooks/usePatchForm';
+
 import { patchFormApprove, patchFormCancel, patchFormReject } from './api';
-import { PutFormRequest } from './type';
-import { usePatchForm } from '../hooks/usePatchForm';
+import { PatchFormRequest } from './type';
 
 export const usePatchFormApprove = () =>
   usePatchForm<string>({
@@ -10,7 +11,7 @@ export const usePatchFormApprove = () =>
   });
 
 export const usePatchFormReject = () =>
-  usePatchForm<PutFormRequest>({
+  usePatchForm<PatchFormRequest>({
     mutationFn: (request) => patchFormReject(request),
     successMessage: '요청거절이 완료되었습니다.',
     errorMessage: '요청거절 중 오류가 발생했습니다.',

--- a/src/app/history/_shared/services/mutation.ts
+++ b/src/app/history/_shared/services/mutation.ts
@@ -1,17 +1,23 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
+import queryKey from '@/app/history/_shared/services/query-key';
 import { customToast } from '@/shared/components/toast/custom-toast/custom-toast';
 
 import { patchFormApprove, patchFormCancel, patchFormReject } from './api';
 import { PutFormRequest } from './type';
 
 export const usePutFormApprove = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: (applicationFormId: string) =>
       patchFormApprove(applicationFormId),
     onSuccess: () => {
       customToast({
         description: '요청수락이 완료되었습니다.',
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKey.getFormList(),
       });
     },
     onError: () => {
@@ -22,11 +28,16 @@ export const usePutFormApprove = () => {
   });
 };
 export const usePutFormReject = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: (request: PutFormRequest) => patchFormReject(request),
     onSuccess: () => {
       customToast({
         description: '요청거절이 완료되었습니다.',
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKey.getFormList(),
       });
     },
     onError: () => {
@@ -38,12 +49,17 @@ export const usePutFormReject = () => {
 };
 
 export const usePutFormCancel = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: (applicationFormId: string) =>
       patchFormCancel(applicationFormId),
     onSuccess: () => {
       customToast({
         description: '취소가 완료되었습니다.',
+      });
+      queryClient.invalidateQueries({
+        queryKey: queryKey.getFormList(),
       });
     },
     onError: () => {

--- a/src/app/history/_shared/services/query-key.ts
+++ b/src/app/history/_shared/services/query-key.ts
@@ -1,7 +1,8 @@
 import { GetFormListRequest } from './type';
 
 const queryKey = {
-  getFormList: (request?: GetFormListRequest) => ['getFormList', request],
+  getFormList: (request?: GetFormListRequest) =>
+    request ? ['getFormList', request] : ['getFormList'],
   getRejectionReason: (applicationFormId: string) => [
     'getRejectReason',
     applicationFormId,

--- a/src/app/history/_shared/services/type.ts
+++ b/src/app/history/_shared/services/type.ts
@@ -18,7 +18,7 @@ interface GetFormListRequest {
 
 type GetFormListResponse = Pagination<Form>;
 
-interface PutFormRequest {
+interface PatchFormRequest {
   applicationFormId: string;
   applicationFormRejectedType: ApplicationRejectedType;
   otherMemo: string;
@@ -32,6 +32,6 @@ interface GetRejectionReasonResponse {
 export type {
   GetFormListRequest,
   GetFormListResponse,
-  PutFormRequest,
+  PatchFormRequest,
   GetRejectionReasonResponse,
 };

--- a/src/shared/constants/type-mapping.ts
+++ b/src/shared/constants/type-mapping.ts
@@ -31,7 +31,7 @@ export const APPLICATION_STATUS_LABEL_MAP: Record<
   PENDING: '수락 대기 중',
   REJECTED: '거절됨',
   CANCELED: '취소됨',
-  ACCEPTED: '수락완료',
+  APPROVED: '수락완료',
   CANCELED_IN_PROCESS: '진행취소',
 };
 

--- a/src/shared/types/form.ts
+++ b/src/shared/types/form.ts
@@ -5,7 +5,7 @@ type ApplicationFormStatus =
   | 'PENDING'
   | 'REJECTED'
   | 'CANCELED'
-  | 'ACCEPTED'
+  | 'APPROVED'
   | 'CANCELED_IN_PROCESS';
 
 type ApplicationRejectedType =


### PR DESCRIPTION
## 💻구현 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)
- #111 
- 쿼리키 수정
- ACCEPTED -> APPROVED 로 수정
<br><br>

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br><br>

## #️⃣연관된 이슈

> 아래에 {이슈번호}를 작성해주세요
> <br>
> close #111

<br><br>

## ⚠️코멘트

> 리뷰어에게 남길 코멘트가 있다면 작성해주세요

<br><br>

## ✅Check List

- [ ] PR 제목 규칙
- [ ] 추가/수정사항
- [ ] 이슈번호


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Unified form actions (approve/reject/cancel) to use a consistent patch-based flow with standardized success/error messages.
- Style
  - Status terminology updated in the UI from “Accepted” to “Approved” (visual label preserved).
- Bug Fixes
  - Improved form list cache key handling to reduce stale list states and make post-action refreshes more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->